### PR TITLE
Add comprehensive test failure analysis for ModuleViewerComponent

### DIFF
--- a/TEST_FAILURE_ANALYSIS.md
+++ b/TEST_FAILURE_ANALYSIS.md
@@ -1,0 +1,363 @@
+# ModuleViewerComponent Test Failures - Analysis Report
+
+## Executive Summary
+
+The `ModuleViewerComponent` test suite has been undergoing continuous debugging attempts with **18 commits** made between November 15-16, 2025, cycling through various approaches to fix persistent async timing and dependency injection issues. Despite multiple strategies, the tests continue to fail, indicating a fundamental architectural or timing issue that hasn't been properly addressed.
+
+## Component Overview
+
+**File:** `elohim-app/src/app/docs/components/module-viewer/module-viewer.component.ts`
+
+The `ModuleViewerComponent` is an Angular component that:
+- Subscribes to route parameters in `ngOnInit()` to get a module ID
+- Uses `DocumentGraphService` to fetch epic, feature, and scenario nodes
+- Builds an interleaved view combining epic sections and scenarios
+- Sanitizes and renders markdown content
+
+**Test File:** `elohim-app/src/app/docs/components/module-viewer/module-viewer.component.spec.ts`
+
+## Core Problem
+
+The fundamental issue is that **the component's `ngOnInit()` method subscribes to `route.params` Observable, and the tests cannot reliably ensure this subscription fires and completes before assertions run.**
+
+### Specific Symptoms:
+- `moduleName` remains empty instead of being set to 'Value Scanner: Care Economy'
+- `getNodesByType()` is never called during tests
+- Component state is not properly initialized before assertions
+- Timing mismatches between when the component subscribes and when test data is emitted
+
+## Chronological Fix Attempts
+
+### Phase 1: Basic Mock Setup Issues (Commits 1-4)
+
+#### Attempt 1: Fix mock setup for getNodesByType (1eb2667)
+**Date:** Nov 15, 19:05
+**Author:** Claude
+**Approach:** Changed from `returnValue` to `callFake` to handle different arguments
+```typescript
+mockDocumentGraphService.getNodesByType.and.callFake((type: string) => {
+  if (type === 'epic') return [mockEpicNode as any];
+  if (type === 'feature') return [mockFeatureNode as any];
+  return [];
+});
+```
+**Result:** Failed - component still couldn't initialize properly
+
+#### Attempt 2: Add DomSanitizer mock (0369a68)
+**Date:** Nov 15, 19:13
+**Author:** Claude
+**Approach:** Added missing `DomSanitizer` dependency
+```typescript
+const mockDomSanitizer = jasmine.createSpyObj('DomSanitizer', ['sanitize']);
+mockDomSanitizer.sanitize.and.returnValue('');
+```
+**Reasoning:** Component requires DomSanitizer for rendering markdown
+**Result:** Failed - still couldn't trigger ngOnInit properly
+
+#### Attempt 3: Move mock setup to beforeEach (b60eedd)
+**Date:** Nov 15, 19:21
+**Author:** Claude
+**Approach:** Configured all mock behaviors in `beforeEach()` before component creation
+**Reasoning:** Ensure mocks are ready before component initialization
+**Result:** Failed - async timing issues still present
+
+---
+
+### Phase 2: Async Timing Experiments (Commits 5-8)
+
+#### Attempt 4: Add fakeAsync/tick (7898f0c)
+**Date:** Nov 15, 20:12
+**Author:** Claude
+**Approach:** Wrapped tests in `fakeAsync()` and called `tick()` after `detectChanges()`
+```typescript
+it('should load value-scanner module on init', fakeAsync(() => {
+  fixture.detectChanges();
+  tick();
+  expect(component.moduleName).toBe('Value Scanner: Care Economy');
+}));
+```
+**Reasoning:** Process async Observable subscriptions synchronously
+**Result:** Failed - Observable subscription still didn't fire reliably
+
+#### Attempt 5: Switch to BehaviorSubject (bae09b5)
+**Date:** Nov 15, 20:22
+**Author:** Claude
+**Approach:** Replaced `of()` with `BehaviorSubject` for route params
+```typescript
+paramsSubject = new BehaviorSubject({ id: 'value-scanner' });
+// ...
+{ provide: ActivatedRoute, useValue: { params: paramsSubject.asObservable() } }
+```
+**Reasoning:** BehaviorSubject emits current value to new subscribers immediately
+**Result:** Failed - timing issues persisted
+
+#### Attempt 6: Replace fakeAsync with async/whenStable (193372e)
+**Date:** Nov 15, 20:27
+**Author:** Claude
+**Approach:** Switched from `fakeAsync/tick` to `async/await` with `fixture.whenStable()`
+```typescript
+it('should load value-scanner module on init', async () => {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  expect(component.moduleName).toBe('Value Scanner: Care Economy');
+});
+```
+**Reasoning:** `whenStable()` waits for all async operations to complete
+**Result:** Failed - subscription still not firing
+
+#### Attempt 7: Explicitly emit params after detectChanges (b211547)
+**Date:** Nov 15, 20:32
+**Author:** Claude
+**Approach:** Added explicit `paramsSubject.next()` call after `detectChanges()`
+```typescript
+fixture.detectChanges(); // Subscribe in ngOnInit
+paramsSubject.next({ id: 'value-scanner' }); // Explicitly emit
+await fixture.whenStable();
+```
+**Reasoning:** Force emission to trigger subscription callback
+**Result:** Failed - double emission didn't help
+
+---
+
+### Phase 3: Emission Ordering Experiments (Commits 8-11)
+
+#### Attempt 8: Emit params BEFORE detectChanges (c980748)
+**Date:** Nov 15, 20:41
+**Author:** Claude
+**Approach:** Reversed order - emit before subscribing
+```typescript
+paramsSubject = new BehaviorSubject<any>({}); // Empty initially
+// In test:
+paramsSubject.next({ id: 'value-scanner' }); // Set value first
+fixture.detectChanges(); // Then subscribe
+```
+**Reasoning:** Ensure BehaviorSubject has value before subscription
+**Result:** Failed - order reversal didn't solve the issue
+
+#### Attempt 9: detectChanges, emit, detectChanges (98cfc48)
+**Date:** Nov 15, 21:24
+**Author:** Matthew
+**Approach:** Three-step process
+```typescript
+fixture.detectChanges(); // Initialize and subscribe
+paramsSubject.next({ id: 'value-scanner' }); // Emit
+fixture.detectChanges(); // Process changes from loadModule
+await fixture.whenStable();
+```
+**Reasoning:** First detectChanges subscribes, next processes the emitted values
+**Result:** Failed - triple-step didn't work
+
+---
+
+### Phase 4: Component Architecture Changes (Commits 11-14)
+
+#### Attempt 10: Switch to DestroyRef/takeUntilDestroyed (730a839)
+**Date:** Nov 15, 21:42
+**Author:** Matthew
+**Approach:** Changed from `Subject/takeUntil` to Angular's `DestroyRef`
+```typescript
+// Component:
+this.route.params
+  .pipe(takeUntilDestroyed(this.destroyRef))
+  .subscribe(params => { ... });
+
+// Test:
+const mockDestroyRef = jasmine.createSpyObj('DestroyRef', ['onDestroy']);
+```
+**Reasoning:** Use more idiomatic Angular pattern for cleanup
+**Result:** Failed - DestroyRef mock needed proper implementation
+
+#### Attempt 11: Improve DestroyRef mock (3430353)
+**Date:** Nov 15, 21:55
+**Author:** Matthew
+**Approach:** Created proper DestroyRef mock with callback storage
+```typescript
+const mockDestroyRef: DestroyRef = {
+  onDestroy: (callback: () => void) => {
+    return; // Store but don't call
+  }
+};
+```
+**Result:** Failed - still timing issues
+
+#### Attempt 12: Fix DestroyRef return value (a085d79)
+**Date:** Nov 15, 21:59
+**Author:** Matthew
+**Approach:** Return no-op function from onDestroy
+```typescript
+onDestroy: (callback: () => void) => {
+  return () => {}; // Return cleanup function
+}
+```
+**Result:** Failed - mock signature corrected but tests still failing
+
+#### Attempt 13: Revert to Subject/takeUntil pattern (df837e4)
+**Date:** Nov 15, 22:32
+**Author:** Matthew
+**Approach:** Removed DestroyRef, went back to `Subject` with `OnDestroy`
+```typescript
+// Component:
+private destroy$ = new Subject<void>();
+
+ngOnInit(): void {
+  this.route.params
+    .pipe(takeUntil(this.destroy$))
+    .subscribe(params => { ... });
+}
+
+ngOnDestroy(): void {
+  this.destroy$.next();
+  this.destroy$.complete();
+}
+```
+**Reasoning:** Revert to more testable pattern
+**Result:** Failed - architectural change didn't solve timing
+
+---
+
+### Phase 5: Latest Timing Refinements (Commits 14-18)
+
+#### Attempt 14: Initialize BehaviorSubject with params (6361c8c)
+**Date:** Nov 15, 22:36
+**Author:** Matthew
+**Approach:** Set initial value in BehaviorSubject constructor
+```typescript
+paramsSubject = new BehaviorSubject<any>({ id: 'value-scanner' });
+// Provide as Observable:
+{ provide: ActivatedRoute, useValue: { params: paramsSubject.asObservable() } }
+// Simplified tests - no manual emission
+```
+**Reasoning:** Subscription should receive initial value immediately
+**Result:** Failed - still not triggering
+
+#### Attempt 15: Provide BehaviorSubject directly (7bb6446)
+**Date:** Nov 15, 22:41
+**Author:** Matthew
+**Approach:** Pass BehaviorSubject instead of `.asObservable()`
+```typescript
+{ provide: ActivatedRoute, useValue: { params: paramsSubject } }
+```
+**Reasoning:** Maybe `.asObservable()` was causing timing issues
+**Result:** Unknown - latest attempt
+
+#### Attempts 16-18: Further timing adjustments
+- Moving `detectChanges()` to `beforeEach()` (latest)
+- Calling `ngOnInit()` manually in error-path tests
+- Various comment updates explaining the reasoning
+
+---
+
+## Patterns Identified
+
+### What Was Tried:
+1. ✅ Mock configuration (callFake vs returnValue)
+2. ✅ Dependency injection (DomSanitizer, DestroyRef)
+3. ✅ fakeAsync/tick approach
+4. ✅ async/await with whenStable
+5. ✅ BehaviorSubject vs Observable.of()
+6. ✅ Manual param emission timing (before/after detectChanges)
+7. ✅ Multiple detectChanges() calls
+8. ✅ Component architecture changes (DestroyRef vs Subject)
+9. ✅ Observable provision methods (.asObservable() vs direct)
+10. ✅ Initial value in BehaviorSubject constructor
+
+### What Hasn't Been Tried:
+1. ❌ Using `TestScheduler` from RxJS for precise timing control
+2. ❌ Calling component lifecycle methods manually in tests
+3. ❌ Using `done()` callback in async tests for explicit completion
+4. ❌ Inspecting the actual subscription timing with debugging
+5. ❌ Testing with real `ActivatedRoute` instead of mocks
+6. ❌ Refactoring component to make it more testable (dependency injection of params)
+7. ❌ Using Marble testing for Observable behavior
+8. ❌ Checking if Angular zone is running properly in tests
+9. ❌ Testing with actual routing instead of mocked ActivatedRoute
+
+## Root Cause Hypothesis
+
+Based on the cycling pattern of attempts, the likely root causes are:
+
+1. **Zone.js Timing Issue**: Angular's change detection and RxJS subscriptions may not be properly synchronized in the test environment
+
+2. **Mock vs Real ActivatedRoute Mismatch**: The mocked `ActivatedRoute.params` may not behave identically to the real implementation, especially regarding subscription timing
+
+3. **Component Design**: The component tightly couples routing, data fetching, and rendering, making it difficult to test in isolation
+
+4. **Test Environment Configuration**: Karma/Jasmine configuration may not properly handle async operations or Angular's zone
+
+## Recommendations for Senior Developer
+
+### Immediate Diagnostic Steps:
+1. Add debug logging to both component and test to trace exact execution order
+2. Check if ngOnInit is actually being called
+3. Verify that the subscription in ngOnInit is actually created
+4. Confirm that route.params is emitting at all
+
+### Potential Solutions:
+
+#### Option 1: Refactor for Testability
+```typescript
+// Make params an input or extract logic
+export class ModuleViewerComponent {
+  @Input() moduleId: string;
+
+  ngOnInit(): void {
+    this.loadModule(this.moduleId);
+  }
+}
+```
+
+#### Option 2: Use Real Routing in Tests
+```typescript
+await TestBed.configureTestingModule({
+  imports: [
+    ModuleViewerComponent,
+    RouterTestingModule.withRoutes([
+      { path: 'module/:id', component: ModuleViewerComponent }
+    ])
+  ]
+});
+
+router.navigate(['/module/value-scanner']);
+await fixture.whenStable();
+```
+
+#### Option 3: Manual Lifecycle Control
+```typescript
+it('should load value-scanner module on init', async () => {
+  // Don't call detectChanges in beforeEach
+  component.ngOnInit(); // Call explicitly
+  await fixture.whenStable();
+  fixture.detectChanges(); // Update view
+  // assertions
+});
+```
+
+#### Option 4: Use Marble Testing
+```typescript
+import { TestScheduler } from 'rxjs/testing';
+
+it('should load value-scanner module on init', () => {
+  const testScheduler = new TestScheduler(...);
+  testScheduler.run(({ cold, expectObservable }) => {
+    const params$ = cold('a|', { a: { id: 'value-scanner' } });
+    // Test Observable behavior precisely
+  });
+});
+```
+
+## Files to Review
+
+1. **karma.conf.js** - Test runner configuration
+2. **tsconfig.spec.json** - TypeScript test configuration
+3. **Angular version and dependencies** - May be version-specific issues
+4. **Other working async tests** - Compare patterns that work
+
+## Conclusion
+
+After 18 commits cycling through various async timing approaches, the tests remain broken. This suggests the problem is not with the timing approach itself, but either:
+- A fundamental architectural issue in how the component is designed
+- A test environment configuration problem
+- A misunderstanding of how Angular's TestBed handles async operations
+- A bug or limitation in the testing framework
+
+**Next steps should focus on understanding WHY none of these approaches worked rather than trying more timing variations.**


### PR DESCRIPTION
Documented all 18 commit attempts to fix the failing unit tests for ModuleViewerComponent. This analysis covers:

- Chronological breakdown of every attempted fix with code samples
- Mock configuration issues (DomSanitizer, getNodesByType)
- Async timing experiments (fakeAsync/tick, async/whenStable, BehaviorSubject)
- Emission ordering variations (before/after detectChanges)
- Component architecture changes (DestroyRef vs Subject/takeUntil)
- Root cause hypotheses and recommendations

The cycling pattern of attempts suggests a fundamental architectural or test environment issue rather than a simple timing problem. Document includes 4 concrete alternative solutions and diagnostic steps for senior developer review.