### PR TITLE
Fix flaky ThemeService test by clearing localStorage before service i…

### DIFF
--- a/elohim-app/src/app/services/theme.service.spec.ts
+++ b/elohim-app/src/app/services/theme.service.spec.ts
@@ -5,9 +5,9 @@ describe('ThemeService', () => {
   let service: ThemeService;
 
   beforeEach(() => {
+    localStorage.clear();
     TestBed.configureTestingModule({});
     service = TestBed.inject(ThemeService);
-    localStorage.clear();
   });
 
   it('should be created', () => {


### PR DESCRIPTION
…nitialization

The test "should default to device theme" was flaky because:
- ThemeService was being created before localStorage.clear() was called
- The service constructor immediately calls loadTheme() which reads localStorage
- Previous tests would save themes ('light', 'dark') to localStorage
- This caused the test to fail when localStorage contained data from previous tests

Fix: Move localStorage.clear() before TestBed.inject(ThemeService) to ensure clean state before service initialization.

Fixes inconsistent test results in CI/CD.