### PR TITLE
Fix lamad contrast issues with proper light/dark theme support

### DIFF
--- a/elohim-app/src/app/lamad/components/content-viewer/content-viewer.component.css
+++ b/elohim-app/src/app/lamad/components/content-viewer/content-viewer.component.css
@@ -9,11 +9,12 @@
 .error-state {
   text-align: center;
   padding: 3rem;
+  color: var(--lamad-text-secondary);
 }
 
 .spinner {
-  border: 4px solid #f3f3f3;
-  border-top: 4px solid #667eea;
+  border: 4px solid rgba(99, 102, 241, 0.1);
+  border-top: 4px solid var(--lamad-accent-primary);
   border-radius: 50%;
   width: 50px;
   height: 50px;
@@ -28,18 +29,20 @@
 
 /* Back button */
 .back-button {
-  background: #f3f4f6;
-  border: none;
+  background: var(--lamad-surface);
+  border: 1px solid var(--lamad-border);
   padding: 0.75rem 1.25rem;
   border-radius: 8px;
   cursor: pointer;
   font-size: 1rem;
   margin-bottom: 2rem;
   transition: all 0.2s;
+  color: var(--lamad-text-secondary);
 }
 
 .back-button:hover {
-  background: #e5e7eb;
+  background: var(--lamad-surface-hover);
+  border-color: var(--lamad-border-hover);
   transform: translateX(-4px);
 }
 
@@ -49,18 +52,19 @@
 }
 
 .header-main {
-  background: white;
+  background: var(--lamad-surface);
   padding: 2rem;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   margin-bottom: 1.5rem;
+  border: 1px solid var(--lamad-border);
 }
 
 .content-type-badge {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--lamad-accent-gradient);
   color: white;
   padding: 0.5rem 1rem;
   border-radius: 20px;
@@ -75,13 +79,13 @@
 .content-title {
   font-size: 2.5rem;
   margin: 1rem 0;
-  color: #1a1a1a;
+  color: var(--lamad-text-primary);
   line-height: 1.3;
 }
 
 .content-description {
   font-size: 1.2rem;
-  color: #666;
+  color: var(--lamad-text-tertiary);
   margin: 1rem 0;
   line-height: 1.6;
 }
@@ -92,11 +96,11 @@
   flex-wrap: wrap;
   margin: 1.5rem 0;
   padding-top: 1rem;
-  border-top: 1px solid #e5e7eb;
+  border-top: 1px solid var(--lamad-border);
 }
 
 .meta-item {
-  color: #4b5563;
+  color: var(--lamad-text-tertiary);
   font-size: 0.95rem;
 }
 
@@ -108,20 +112,22 @@
 }
 
 .tag {
-  background: #e0e7ff;
-  color: #4338ca;
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--lamad-accent-primary);
   padding: 0.4rem 0.8rem;
   border-radius: 6px;
   font-size: 0.85rem;
   font-weight: 500;
+  border: 1px solid var(--lamad-border);
 }
 
 /* Affinity panel */
 .affinity-panel {
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  background: var(--lamad-surface);
   padding: 1.5rem;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--lamad-border);
 }
 
 .affinity-display {
@@ -143,24 +149,28 @@
 }
 
 .affinity-circle.affinity-unseen {
-  background: #9ca3af;
+  background: #64748b;
+  box-shadow: 0 0 16px rgba(100, 116, 139, 0.3);
 }
 
 .affinity-circle.affinity-low {
   background: linear-gradient(135deg, #3b82f6, #60a5fa);
+  box-shadow: 0 0 16px rgba(59, 130, 246, 0.3);
 }
 
 .affinity-circle.affinity-medium {
   background: linear-gradient(135deg, #f59e0b, #fbbf24);
+  box-shadow: 0 0 16px rgba(245, 158, 11, 0.3);
 }
 
 .affinity-circle.affinity-high {
   background: linear-gradient(135deg, #10b981, #34d399);
+  box-shadow: 0 0 16px rgba(16, 185, 129, 0.3);
 }
 
 .affinity-label {
   font-size: 0.9rem;
-  color: #4b5563;
+  color: var(--lamad-text-tertiary);
   font-weight: 500;
 }
 
@@ -172,19 +182,20 @@
 
 .btn-affinity {
   flex: 1;
-  background: white;
-  border: 2px solid #e5e7eb;
+  background: var(--lamad-bg-tertiary);
+  border: 2px solid var(--lamad-border);
   padding: 0.75rem;
   border-radius: 8px;
   cursor: pointer;
   font-size: 0.95rem;
   font-weight: 500;
   transition: all 0.2s;
+  color: var(--lamad-text-secondary);
 }
 
 .btn-affinity:hover:not(:disabled) {
-  background: #f9fafb;
-  border-color: #667eea;
+  background: var(--lamad-surface-hover);
+  border-color: var(--lamad-accent-primary);
   transform: translateY(-2px);
 }
 
@@ -201,29 +212,30 @@
 
 .btn-quick {
   flex: 1;
-  background: white;
-  border: 2px solid #e5e7eb;
+  background: var(--lamad-bg-tertiary);
+  border: 2px solid var(--lamad-border);
   padding: 0.75rem;
   border-radius: 8px;
   cursor: pointer;
   font-size: 0.9rem;
   transition: all 0.2s;
+  color: var(--lamad-text-secondary);
 }
 
 .btn-quick:hover {
-  border-color: #667eea;
+  border-color: var(--lamad-accent-primary);
   transform: translateY(-2px);
 }
 
 .btn-quick.active {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--lamad-accent-gradient);
   color: white;
   border-color: transparent;
 }
 
 .affinity-bar {
   height: 10px;
-  background: rgba(255, 255, 255, 0.6);
+  background: var(--lamad-bg-tertiary);
   border-radius: 5px;
   overflow: hidden;
 }
@@ -235,7 +247,7 @@
 }
 
 .affinity-bar-fill.affinity-unseen {
-  background: #9ca3af;
+  background: #64748b;
 }
 
 .affinity-bar-fill.affinity-low {
@@ -252,88 +264,134 @@
 
 /* Content body */
 .content-body {
-  background: white;
+  background: var(--lamad-surface);
   padding: 2.5rem;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   margin-bottom: 2rem;
   line-height: 1.7;
+  border: 1px solid var(--lamad-border);
+  color: var(--lamad-text-secondary);
 }
 
 /* Markdown content */
+.markdown-content {
+  color: var(--lamad-text-secondary);
+}
+
 .markdown-content h1 {
   font-size: 2rem;
   margin: 2rem 0 1rem;
-  color: #1a1a1a;
+  color: var(--lamad-text-primary);
 }
 
 .markdown-content h2 {
   font-size: 1.6rem;
   margin: 1.5rem 0 0.75rem;
-  color: #1a1a1a;
+  color: var(--lamad-text-primary);
 }
 
 .markdown-content h3 {
   font-size: 1.3rem;
   margin: 1.25rem 0 0.5rem;
-  color: #1a1a1a;
+  color: var(--lamad-text-primary);
+}
+
+.markdown-content p {
+  color: var(--lamad-text-secondary);
+  margin: 0 0 1rem;
+}
+
+.markdown-content strong {
+  color: var(--lamad-text-primary);
+}
+
+.markdown-content em {
+  color: var(--lamad-text-tertiary);
+}
+
+.markdown-content a {
+  color: var(--lamad-accent-primary);
+  text-decoration: none;
+  border-bottom: 1px solid var(--lamad-accent-primary);
+}
+
+.markdown-content a:hover {
+  color: var(--lamad-accent-secondary);
+  border-bottom-color: var(--lamad-accent-secondary);
 }
 
 .markdown-content code {
-  background: #f3f4f6;
+  background: var(--lamad-bg-tertiary);
   padding: 0.2rem 0.4rem;
   border-radius: 4px;
   font-family: 'Courier New', monospace;
   font-size: 0.9em;
+  color: var(--lamad-accent-primary);
+  border: 1px solid var(--lamad-border);
 }
 
 .markdown-content pre {
-  background: #1e293b;
-  color: #e2e8f0;
+  background: var(--lamad-bg-primary);
+  color: var(--lamad-text-secondary);
   padding: 1.5rem;
   border-radius: 8px;
   overflow-x: auto;
   margin: 1rem 0;
+  border: 1px solid var(--lamad-border);
 }
 
 .markdown-content pre code {
   background: none;
   padding: 0;
   color: inherit;
+  border: none;
+}
+
+.markdown-content ul,
+.markdown-content ol {
+  margin: 1rem 0;
+  padding-left: 2rem;
+  color: var(--lamad-text-secondary);
+}
+
+.markdown-content li {
+  margin: 0.5rem 0;
 }
 
 /* Gherkin content */
 .gherkin-content {
-  background: #1e293b;
+  background: var(--lamad-bg-primary);
   border-radius: 8px;
   overflow: hidden;
+  border: 1px solid var(--lamad-border);
 }
 
 .gherkin-content pre {
   margin: 0;
   padding: 1.5rem;
-  color: #e2e8f0;
+  color: var(--lamad-text-secondary);
   font-family: 'Courier New', monospace;
   font-size: 0.95rem;
   line-height: 1.6;
 }
 
 .gherkin-tag {
-  color: #a78bfa;
+  color: var(--lamad-accent-secondary);
   font-weight: 500;
 }
 
 .gherkin-keyword {
-  color: #60a5fa;
+  color: var(--lamad-info);
   font-weight: bold;
 }
 
 .gherkin-table {
-  color: #fbbf24;
+  color: var(--lamad-warning);
 }
 
 .gherkin-comment {
-  color: #94a3b8;
+  color: var(--lamad-text-muted);
   font-style: italic;
 }
 
@@ -345,7 +403,7 @@
 .related-section h2 {
   font-size: 1.8rem;
   margin-bottom: 1.5rem;
-  color: #1a1a1a;
+  color: var(--lamad-text-primary);
 }
 
 .related-grid {
@@ -355,19 +413,19 @@
 }
 
 .related-card {
-  background: white;
+  background: var(--lamad-surface);
   padding: 1.5rem;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   cursor: pointer;
   transition: all 0.3s;
-  border: 2px solid transparent;
+  border: 2px solid var(--lamad-border);
 }
 
 .related-card:hover {
   transform: translateY(-4px);
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
-  border-color: #667eea;
+  border-color: var(--lamad-accent-primary);
 }
 
 .related-header {
@@ -378,8 +436,8 @@
 }
 
 .related-type {
-  background: #f3f4f6;
-  color: #4b5563;
+  background: var(--lamad-bg-tertiary);
+  color: var(--lamad-text-tertiary);
   padding: 0.25rem 0.75rem;
   border-radius: 12px;
   font-size: 0.8rem;
@@ -387,7 +445,7 @@
 }
 
 .related-affinity {
-  color: #667eea;
+  color: var(--lamad-accent-primary);
   font-weight: bold;
   font-size: 0.9rem;
 }
@@ -395,12 +453,12 @@
 .related-title {
   font-size: 1.1rem;
   margin: 0.5rem 0;
-  color: #1a1a1a;
+  color: var(--lamad-text-primary);
 }
 
 .related-description {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--lamad-text-tertiary);
   margin: 0.5rem 0;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -410,7 +468,7 @@
 
 /* Buttons */
 .btn-primary {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: var(--lamad-accent-gradient);
   color: white;
   border: none;
   padding: 0.75rem 1.5rem;
@@ -423,6 +481,7 @@
 
 .btn-primary:hover {
   transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
 }
 
 /* Responsive */

--- a/elohim-app/src/app/lamad/components/lamad-home/lamad-home.component.css
+++ b/elohim-app/src/app/lamad/components/lamad-home/lamad-home.component.css
@@ -1,138 +1,803 @@
 /* Three-Panel Layout */
-.lamad-home-container{width:100%;height:100vh;overflow:hidden;background:linear-gradient(135deg,#0f172a 0%,#1e293b 100%);color:#e2e8f0}
-.loading-container{display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;gap:1rem}
-.loading-spinner{width:48px;height:48px;border:4px solid rgba(99,102,241,.2);border-top-color:#6366f1;border-radius:50%;animation:spin 1s linear infinite}
-@keyframes spin{to{transform:rotate(360deg)}}
-.three-panel-layout{display:flex;height:100vh;overflow:hidden}
+.lamad-home-container {
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  background: linear-gradient(135deg, var(--lamad-bg-primary) 0%, var(--lamad-bg-secondary) 100%);
+  color: var(--lamad-text-secondary);
+}
+
+.loading-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 1rem;
+}
+
+.loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid rgba(99, 102, 241, 0.2);
+  border-top-color: var(--lamad-accent-primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.three-panel-layout {
+  display: flex;
+  height: 100vh;
+  overflow: hidden;
+}
 
 /* Sidebar */
-.nav-sidebar{width:280px;min-width:280px;height:100vh;background:rgba(15,23,42,.95);border-right:1px solid rgba(99,102,241,.2);display:flex;flex-direction:column;overflow:hidden}
-.sidebar-header{padding:1.5rem 1rem;border-bottom:1px solid rgba(99,102,241,.2);background:rgba(99,102,241,.05)}
-.sidebar-title{font-size:1.125rem;font-weight:600;color:#818cf8;margin:0 0 1rem 0}
-.path-progress{display:flex;flex-direction:column;gap:.5rem}
-.progress-bar{height:6px;background:rgba(99,102,241,.2);border-radius:3px;overflow:hidden}
-.progress-fill{height:100%;background:linear-gradient(90deg,#6366f1,#8b5cf6);transition:width .3s}
-.progress-text{font-size:.75rem;color:#94a3b8;text-align:center}
-.path-nav{flex:1;overflow-y:auto;overflow-x:hidden;padding:.5rem 0}
-.path-nav::-webkit-scrollbar{width:6px}
-.path-nav::-webkit-scrollbar-track{background:rgba(15,23,42,.5)}
-.path-nav::-webkit-scrollbar-thumb{background:rgba(99,102,241,.3);border-radius:3px}
-.path-nav::-webkit-scrollbar-thumb:hover{background:rgba(99,102,241,.5)}
-.path-item{padding:.75rem 1rem;margin:.25rem .5rem;border-radius:.5rem;cursor:pointer;transition:all .2s;background:rgba(30,41,59,.3);border:1px solid transparent}
-.path-item:hover{background:rgba(99,102,241,.1);border-color:rgba(99,102,241,.3);transform:translateX(2px)}
-.path-item.selected{background:linear-gradient(135deg,rgba(99,102,241,.2),rgba(139,92,246,.2));border-color:rgba(99,102,241,.5);box-shadow:0 2px 8px rgba(99,102,241,.3)}
-.path-item.depth-1{margin-left:1.5rem;font-size:.875rem}
-.path-item-content{display:flex;align-items:center;justify-content:space-between;gap:.5rem}
-.path-item-header{display:flex;align-items:center;gap:.5rem;flex:1;min-width:0}
-.path-order{display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;background:rgba(99,102,241,.2);border-radius:50%;font-size:.7rem;font-weight:600;color:#818cf8;flex-shrink:0}
-.path-icon{font-size:1rem;flex-shrink:0}
-.path-title{font-size:.875rem;line-height:1.3;color:#e2e8f0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.category-badge{margin-top:.25rem;font-size:.7rem;color:#64748b;text-transform:uppercase;letter-spacing:.05em}
-.affinity-indicator{display:flex;align-items:center;justify-content:center;flex-shrink:0}
-.affinity-dot{width:8px;height:8px;border-radius:50%;transition:all .3s}
-.affinity-unseen .affinity-dot{background:#475569;box-shadow:0 0 4px rgba(71,85,105,.5)}
-.affinity-low .affinity-dot{background:#fbbf24;box-shadow:0 0 8px rgba(251,191,36,.6)}
-.affinity-medium .affinity-dot{background:#60a5fa;box-shadow:0 0 8px rgba(96,165,250,.6)}
-.affinity-high .affinity-dot{background:#34d399;box-shadow:0 0 8px rgba(52,211,153,.6)}
-.sidebar-footer{padding:1rem;border-top:1px solid rgba(99,102,241,.2);display:flex;flex-direction:column;gap:.5rem;background:rgba(15,23,42,.5)}
-.sidebar-link{padding:.5rem;text-align:center;background:rgba(99,102,241,.1);border:1px solid rgba(99,102,241,.2);border-radius:.375rem;color:#94a3b8;text-decoration:none;font-size:.875rem;transition:all .2s}
-.sidebar-link:hover{background:rgba(99,102,241,.2);border-color:rgba(99,102,241,.4);color:#e2e8f0}
+.nav-sidebar {
+  width: 280px;
+  min-width: 280px;
+  height: 100vh;
+  background: var(--lamad-surface);
+  border-right: 1px solid var(--lamad-border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  padding: 1.5rem 1rem;
+  border-bottom: 1px solid var(--lamad-border);
+  background: rgba(99, 102, 241, 0.05);
+}
+
+.sidebar-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--lamad-accent-primary);
+  margin: 0 0 1rem 0;
+}
+
+.path-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.progress-bar {
+  height: 6px;
+  background: var(--lamad-bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--lamad-accent-gradient);
+  transition: width 0.3s;
+}
+
+.progress-text {
+  font-size: 0.75rem;
+  color: var(--lamad-text-tertiary);
+  text-align: center;
+}
+
+.path-nav {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0.5rem 0;
+}
+
+.path-nav::-webkit-scrollbar {
+  width: 6px;
+}
+
+.path-nav::-webkit-scrollbar-track {
+  background: var(--lamad-bg-primary);
+}
+
+.path-nav::-webkit-scrollbar-thumb {
+  background: rgba(99, 102, 241, 0.3);
+  border-radius: 3px;
+}
+
+.path-nav::-webkit-scrollbar-thumb:hover {
+  background: rgba(99, 102, 241, 0.5);
+}
+
+.path-item {
+  padding: 0.75rem 1rem;
+  margin: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  background: var(--lamad-bg-tertiary);
+  border: 1px solid transparent;
+}
+
+.path-item:hover {
+  background: rgba(99, 102, 241, 0.1);
+  border-color: var(--lamad-border-hover);
+  transform: translateX(2px);
+}
+
+.path-item.selected {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(139, 92, 246, 0.2));
+  border-color: var(--lamad-border-hover);
+  box-shadow: 0 2px 8px rgba(99, 102, 241, 0.3);
+}
+
+.path-item.depth-1 {
+  margin-left: 1.5rem;
+  font-size: 0.875rem;
+}
+
+.path-item-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.path-item-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.path-order {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: rgba(99, 102, 241, 0.2);
+  border-radius: 50%;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--lamad-accent-primary);
+  flex-shrink: 0;
+}
+
+.path-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.path-title {
+  font-size: 0.875rem;
+  line-height: 1.3;
+  color: var(--lamad-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.category-badge {
+  margin-top: 0.25rem;
+  font-size: 0.7rem;
+  color: var(--lamad-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.affinity-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.affinity-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  transition: all 0.3s;
+}
+
+.affinity-unseen .affinity-dot {
+  background: #64748b;
+  box-shadow: 0 0 4px rgba(100, 116, 139, 0.5);
+}
+
+.affinity-low .affinity-dot {
+  background: #fbbf24;
+  box-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
+}
+
+.affinity-medium .affinity-dot {
+  background: #60a5fa;
+  box-shadow: 0 0 8px rgba(96, 165, 250, 0.6);
+}
+
+.affinity-high .affinity-dot {
+  background: #34d399;
+  box-shadow: 0 0 8px rgba(52, 211, 153, 0.6);
+}
+
+.sidebar-footer {
+  padding: 1rem;
+  border-top: 1px solid var(--lamad-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: var(--lamad-bg-primary);
+}
+
+.sidebar-link {
+  padding: 0.5rem;
+  text-align: center;
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid var(--lamad-border);
+  border-radius: 0.375rem;
+  color: var(--lamad-text-tertiary);
+  text-decoration: none;
+  font-size: 0.875rem;
+  transition: all 0.2s;
+}
+
+.sidebar-link:hover {
+  background: rgba(99, 102, 241, 0.2);
+  border-color: var(--lamad-border-hover);
+  color: var(--lamad-text-secondary);
+}
 
 /* Content Area */
-.content-area{flex:1;display:flex;flex-direction:column;overflow:hidden}
-.graph-section{background:rgba(15,23,42,.8);border-bottom:1px solid rgba(99,102,241,.2);transition:all .3s}
-.graph-section.collapsed .graph-content{display:none}
-.graph-header{display:flex;align-items:center;justify-content:space-between;padding:1rem 1.5rem;cursor:pointer;user-select:none}
-.graph-header:hover{background:rgba(99,102,241,.05)}
-.graph-title{display:flex;align-items:center;gap:.5rem;font-size:1rem;font-weight:600;color:#818cf8;margin:0}
-.graph-icon{font-size:1.25rem}
-.toggle-btn{background:none;border:none;color:#94a3b8;font-size:1rem;cursor:pointer;transition:transform .3s}
-.toggle-btn.rotated{transform:rotate(-90deg)}
-.graph-content{padding:1rem 1.5rem 1.5rem}
-.stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1rem;margin-bottom:1.5rem}
-.stat-card{background:rgba(30,41,59,.5);border:1px solid rgba(99,102,241,.2);border-radius:.5rem;padding:1rem;text-align:center}
-.stat-label{font-size:.75rem;color:#94a3b8;text-transform:uppercase;letter-spacing:.05em;margin-bottom:.5rem}
-.stat-value{font-size:1.5rem;font-weight:700;color:#e2e8f0}
-.distribution-viz{margin-top:1rem}
-.distribution-bar-container{display:flex;height:24px;border-radius:.5rem;overflow:hidden;margin-bottom:.75rem}
-.distribution-segment{transition:flex .3s;cursor:help}
-.distribution-segment.unseen{background:#475569}
-.distribution-segment.low{background:#fbbf24}
-.distribution-segment.medium{background:#60a5fa}
-.distribution-segment.high{background:#34d399}
-.distribution-legend{display:flex;justify-content:center;gap:1.5rem;font-size:.75rem}
-.legend-item{display:flex;align-items:center;gap:.5rem;color:#94a3b8}
-.legend-dot{width:10px;height:10px;border-radius:50%}
-.legend-dot.unseen{background:#475569}
-.legend-dot.low{background:#fbbf24}
-.legend-dot.medium{background:#60a5fa}
-.legend-dot.high{background:#34d399}
+.content-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.graph-section {
+  background: var(--lamad-surface);
+  border-bottom: 1px solid var(--lamad-border);
+  transition: all 0.3s;
+}
+
+.graph-section.collapsed .graph-content {
+  display: none;
+}
+
+.graph-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.graph-header:hover {
+  background: rgba(99, 102, 241, 0.05);
+}
+
+.graph-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--lamad-accent-primary);
+  margin: 0;
+}
+
+.graph-icon {
+  font-size: 1.25rem;
+}
+
+.toggle-btn {
+  background: none;
+  border: none;
+  color: var(--lamad-text-tertiary);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.3s;
+}
+
+.toggle-btn.rotated {
+  transform: rotate(-90deg);
+}
+
+.graph-content {
+  padding: 1rem 1.5rem 1.5rem;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.stat-card {
+  background: var(--lamad-bg-tertiary);
+  border: 1px solid var(--lamad-border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  color: var(--lamad-text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--lamad-text-primary);
+}
+
+.distribution-viz {
+  margin-top: 1rem;
+}
+
+.distribution-bar-container {
+  display: flex;
+  height: 24px;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  margin-bottom: 0.75rem;
+}
+
+.distribution-segment {
+  transition: flex 0.3s;
+  cursor: help;
+}
+
+.distribution-segment.unseen {
+  background: #64748b;
+}
+
+.distribution-segment.low {
+  background: #fbbf24;
+}
+
+.distribution-segment.medium {
+  background: #60a5fa;
+}
+
+.distribution-segment.high {
+  background: #34d399;
+}
+
+.distribution-legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  font-size: 0.75rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--lamad-text-tertiary);
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.legend-dot.unseen {
+  background: #64748b;
+}
+
+.legend-dot.low {
+  background: #fbbf24;
+}
+
+.legend-dot.medium {
+  background: #60a5fa;
+}
+
+.legend-dot.high {
+  background: #34d399;
+}
 
 /* Content Viewer */
-.content-viewer{flex:1;overflow-y:auto;overflow-x:hidden;background:rgba(15,23,42,.6);display:flex;flex-direction:column}
-.content-viewer::-webkit-scrollbar{width:8px}
-.content-viewer::-webkit-scrollbar-track{background:rgba(15,23,42,.5)}
-.content-viewer::-webkit-scrollbar-thumb{background:rgba(99,102,241,.3);border-radius:4px}
-.content-viewer::-webkit-scrollbar-thumb:hover{background:rgba(99,102,241,.5)}
-.content-header{padding:2rem 3rem;background:rgba(30,41,59,.5);border-bottom:1px solid rgba(99,102,241,.2)}
-.content-meta{display:flex;align-items:center;gap:.75rem;margin-bottom:1rem}
-.content-type-badge{display:inline-flex;align-items:center;gap:.375rem;padding:.375rem .75rem;background:rgba(99,102,241,.2);border:1px solid rgba(99,102,241,.3);border-radius:.375rem;font-size:.875rem;color:#818cf8;text-transform:capitalize}
-.content-category{padding:.375rem .75rem;background:rgba(139,92,246,.2);border:1px solid rgba(139,92,246,.3);border-radius:.375rem;font-size:.875rem;color:#a78bfa}
-.content-title{font-size:2rem;font-weight:700;color:#f1f5f9;margin:0 0 1rem 0;line-height:1.3}
-.content-description{font-size:1.125rem;color:#94a3b8;line-height:1.6;margin:0 0 1.5rem 0}
-.affinity-controls{display:flex;align-items:center;justify-content:space-between;padding:1rem;background:rgba(15,23,42,.5);border:1px solid rgba(99,102,241,.2);border-radius:.5rem}
-.affinity-display{display:flex;align-items:center;gap:1rem}
-.affinity-label{font-size:.875rem;color:#94a3b8}
-.affinity-circle{width:64px;height:64px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:.875rem;font-weight:700;border:3px solid;transition:all .3s}
-.affinity-circle.affinity-unseen{border-color:#475569;background:rgba(71,85,105,.2);color:#94a3b8}
-.affinity-circle.affinity-low{border-color:#fbbf24;background:rgba(251,191,36,.2);color:#fbbf24;box-shadow:0 0 16px rgba(251,191,36,.3)}
-.affinity-circle.affinity-medium{border-color:#60a5fa;background:rgba(96,165,250,.2);color:#60a5fa;box-shadow:0 0 16px rgba(96,165,250,.3)}
-.affinity-circle.affinity-high{border-color:#34d399;background:rgba(52,211,153,.2);color:#34d399;box-shadow:0 0 16px rgba(52,211,153,.3)}
-.affinity-buttons{display:flex;gap:.5rem}
-.affinity-btn{width:36px;height:36px;border-radius:.375rem;border:1px solid rgba(99,102,241,.3);background:rgba(99,102,241,.1);color:#818cf8;font-size:1.25rem;cursor:pointer;transition:all .2s}
-.affinity-btn:hover:not(:disabled){background:rgba(99,102,241,.2);border-color:rgba(99,102,241,.5)}
-.affinity-btn:disabled{opacity:.3;cursor:not-allowed}
-.content-body{flex:1;padding:3rem;max-width:900px;margin:0 auto;width:100%}
+.content-viewer {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--lamad-bg-primary);
+  display: flex;
+  flex-direction: column;
+}
+
+.content-viewer::-webkit-scrollbar {
+  width: 8px;
+}
+
+.content-viewer::-webkit-scrollbar-track {
+  background: var(--lamad-bg-primary);
+}
+
+.content-viewer::-webkit-scrollbar-thumb {
+  background: rgba(99, 102, 241, 0.3);
+  border-radius: 4px;
+}
+
+.content-viewer::-webkit-scrollbar-thumb:hover {
+  background: rgba(99, 102, 241, 0.5);
+}
+
+.content-header {
+  padding: 2rem 3rem;
+  background: var(--lamad-surface);
+  border-bottom: 1px solid var(--lamad-border);
+}
+
+.content-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.content-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  background: rgba(99, 102, 241, 0.2);
+  border: 1px solid var(--lamad-border-hover);
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: var(--lamad-accent-primary);
+  text-transform: capitalize;
+}
+
+.content-category {
+  padding: 0.375rem 0.75rem;
+  background: rgba(139, 92, 246, 0.2);
+  border: 1px solid rgba(139, 92, 246, 0.3);
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: var(--lamad-accent-secondary);
+}
+
+.content-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--lamad-text-primary);
+  margin: 0 0 1rem 0;
+  line-height: 1.3;
+}
+
+.content-description {
+  font-size: 1.125rem;
+  color: var(--lamad-text-tertiary);
+  line-height: 1.6;
+  margin: 0 0 1.5rem 0;
+}
+
+.affinity-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem;
+  background: var(--lamad-bg-tertiary);
+  border: 1px solid var(--lamad-border);
+  border-radius: 0.5rem;
+}
+
+.affinity-display {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.affinity-label {
+  font-size: 0.875rem;
+  color: var(--lamad-text-tertiary);
+}
+
+.affinity-circle {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  font-weight: 700;
+  border: 3px solid;
+  transition: all 0.3s;
+}
+
+.affinity-circle.affinity-unseen {
+  border-color: #64748b;
+  background: rgba(100, 116, 139, 0.2);
+  color: var(--lamad-text-tertiary);
+}
+
+.affinity-circle.affinity-low {
+  border-color: #fbbf24;
+  background: rgba(251, 191, 36, 0.2);
+  color: #fbbf24;
+  box-shadow: 0 0 16px rgba(251, 191, 36, 0.3);
+}
+
+.affinity-circle.affinity-medium {
+  border-color: #60a5fa;
+  background: rgba(96, 165, 250, 0.2);
+  color: #60a5fa;
+  box-shadow: 0 0 16px rgba(96, 165, 250, 0.3);
+}
+
+.affinity-circle.affinity-high {
+  border-color: #34d399;
+  background: rgba(52, 211, 153, 0.2);
+  color: #34d399;
+  box-shadow: 0 0 16px rgba(52, 211, 153, 0.3);
+}
+
+.affinity-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.affinity-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 0.375rem;
+  border: 1px solid var(--lamad-border);
+  background: rgba(99, 102, 241, 0.1);
+  color: var(--lamad-accent-primary);
+  font-size: 1.25rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.affinity-btn:hover:not(:disabled) {
+  background: rgba(99, 102, 241, 0.2);
+  border-color: var(--lamad-border-hover);
+}
+
+.affinity-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.content-body {
+  flex: 1;
+  padding: 3rem;
+  max-width: 900px;
+  margin: 0 auto;
+  width: 100%;
+}
 
 /* Markdown */
-.markdown-content{color:#cbd5e1;line-height:1.8;font-size:1rem}
-.markdown-content h1{font-size:2rem;font-weight:700;color:#f1f5f9;margin:2rem 0 1rem 0;line-height:1.3}
-.markdown-content h2{font-size:1.5rem;font-weight:600;color:#e2e8f0;margin:1.5rem 0 1rem 0;line-height:1.4}
-.markdown-content h3{font-size:1.25rem;font-weight:600;color:#cbd5e1;margin:1.25rem 0 .75rem 0;line-height:1.5}
-.markdown-content p{margin:0 0 1rem 0}
-.markdown-content strong{color:#e2e8f0;font-weight:600}
-.markdown-content em{color:#94a3b8}
-.markdown-content a{color:#818cf8;text-decoration:none;border-bottom:1px solid rgba(129,140,248,.3);transition:all .2s}
-.markdown-content a:hover{color:#a5b4fc;border-bottom-color:rgba(165,180,252,.6)}
-.markdown-content code{background:rgba(99,102,241,.1);border:1px solid rgba(99,102,241,.2);border-radius:.25rem;padding:.125rem .375rem;font-family:Monaco,Menlo,'Courier New',monospace;font-size:.875em;color:#a5b4fc}
-.markdown-content pre{background:rgba(15,23,42,.8);border:1px solid rgba(99,102,241,.2);border-radius:.5rem;padding:1rem;overflow-x:auto;margin:1rem 0}
-.markdown-content pre code{background:none;border:none;padding:0;color:#cbd5e1}
-.gherkin-content{font-family:Monaco,Menlo,'Courier New',monospace;font-size:.9rem;line-height:1.6;background:rgba(15,23,42,.8);border:1px solid rgba(99,102,241,.2);border-radius:.5rem;padding:1.5rem}
-.gherkin-keyword{color:#818cf8;font-weight:600}
-.gherkin-tag{color:#fbbf24}
-.gherkin-table{color:#34d399}
-.gherkin-comment{color:#64748b;font-style:italic}
-.plaintext-content{font-family:Monaco,Menlo,'Courier New',monospace;font-size:.9rem;line-height:1.6;color:#cbd5e1;white-space:pre-wrap;background:rgba(15,23,42,.8);border:1px solid rgba(99,102,241,.2);border-radius:.5rem;padding:1.5rem}
+.markdown-content {
+  color: var(--lamad-text-secondary);
+  line-height: 1.8;
+  font-size: 1rem;
+}
+
+.markdown-content h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--lamad-text-primary);
+  margin: 2rem 0 1rem 0;
+  line-height: 1.3;
+}
+
+.markdown-content h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--lamad-text-primary);
+  margin: 1.5rem 0 1rem 0;
+  line-height: 1.4;
+}
+
+.markdown-content h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--lamad-text-secondary);
+  margin: 1.25rem 0 0.75rem 0;
+  line-height: 1.5;
+}
+
+.markdown-content p {
+  margin: 0 0 1rem 0;
+}
+
+.markdown-content strong {
+  color: var(--lamad-text-primary);
+  font-weight: 600;
+}
+
+.markdown-content em {
+  color: var(--lamad-text-tertiary);
+}
+
+.markdown-content a {
+  color: var(--lamad-accent-primary);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(99, 102, 241, 0.3);
+  transition: all 0.2s;
+}
+
+.markdown-content a:hover {
+  color: var(--lamad-accent-secondary);
+  border-bottom-color: rgba(139, 92, 246, 0.6);
+}
+
+.markdown-content code {
+  background: rgba(99, 102, 241, 0.1);
+  border: 1px solid var(--lamad-border);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  font-family: Monaco, Menlo, 'Courier New', monospace;
+  font-size: 0.875em;
+  color: var(--lamad-accent-primary);
+}
+
+.markdown-content pre {
+  background: var(--lamad-bg-primary);
+  border: 1px solid var(--lamad-border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  overflow-x: auto;
+  margin: 1rem 0;
+}
+
+.markdown-content pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--lamad-text-secondary);
+}
+
+.markdown-content ul,
+.markdown-content ol {
+  margin: 1rem 0;
+  padding-left: 2rem;
+}
+
+.markdown-content li {
+  margin: 0.5rem 0;
+}
+
+.gherkin-content {
+  font-family: Monaco, Menlo, 'Courier New', monospace;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  background: var(--lamad-bg-primary);
+  border: 1px solid var(--lamad-border);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+}
+
+.gherkin-keyword {
+  color: var(--lamad-accent-primary);
+  font-weight: 600;
+}
+
+.gherkin-tag {
+  color: var(--lamad-warning);
+}
+
+.gherkin-table {
+  color: var(--lamad-success);
+}
+
+.gherkin-comment {
+  color: var(--lamad-text-muted);
+  font-style: italic;
+}
+
+.plaintext-content {
+  font-family: Monaco, Menlo, 'Courier New', monospace;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--lamad-text-secondary);
+  white-space: pre-wrap;
+  background: var(--lamad-bg-primary);
+  border: 1px solid var(--lamad-border);
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+}
 
 /* Footer */
-.content-footer{display:flex;align-items:center;justify-content:space-between;padding:1.5rem 3rem;background:rgba(30,41,59,.5);border-top:1px solid rgba(99,102,241,.2)}
-.nav-btn{padding:.75rem 1.5rem;background:linear-gradient(135deg,rgba(99,102,241,.2),rgba(139,92,246,.2));border:1px solid rgba(99,102,241,.3);border-radius:.5rem;color:#e2e8f0;font-size:.875rem;font-weight:500;cursor:pointer;transition:all .2s}
-.nav-btn:hover:not(:disabled){background:linear-gradient(135deg,rgba(99,102,241,.3),rgba(139,92,246,.3));border-color:rgba(99,102,241,.5);transform:translateY(-1px);box-shadow:0 4px 12px rgba(99,102,241,.3)}
-.nav-btn:disabled{opacity:.3;cursor:not-allowed}
-.footer-info{text-align:center}
-.node-position{font-size:.875rem;color:#94a3b8}
+.content-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 3rem;
+  background: var(--lamad-surface);
+  border-top: 1px solid var(--lamad-border);
+}
+
+.nav-btn {
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(139, 92, 246, 0.2));
+  border: 1px solid var(--lamad-border-hover);
+  border-radius: 0.5rem;
+  color: var(--lamad-text-secondary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.nav-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.3), rgba(139, 92, 246, 0.3));
+  border-color: var(--lamad-accent-primary);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.3);
+}
+
+.nav-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.footer-info {
+  text-align: center;
+}
+
+.node-position {
+  font-size: 0.875rem;
+  color: var(--lamad-text-tertiary);
+}
 
 /* Responsive */
-@media (max-width:1024px){
-.nav-sidebar{width:240px;min-width:240px}
-.content-body{padding:2rem}
-.content-header{padding:1.5rem 2rem}
-.content-footer{padding:1rem 2rem}
-.stats-grid{grid-template-columns:repeat(2,1fr)}
+@media (max-width: 1024px) {
+  .nav-sidebar {
+    width: 240px;
+    min-width: 240px;
+  }
+
+  .content-body {
+    padding: 2rem;
+  }
+
+  .content-header {
+    padding: 1.5rem 2rem;
+  }
+
+  .content-footer {
+    padding: 1rem 2rem;
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
-@media (max-width:768px){
-.three-panel-layout{flex-direction:column}
-.nav-sidebar{width:100%;height:auto;max-height:30vh}
-.content-area{height:70vh}
-.content-body{padding:1.5rem}
+
+@media (max-width: 768px) {
+  .three-panel-layout {
+    flex-direction: column;
+  }
+
+  .nav-sidebar {
+    width: 100%;
+    height: auto;
+    max-height: 30vh;
+  }
+
+  .content-area {
+    height: 70vh;
+  }
+
+  .content-body {
+    padding: 1.5rem;
+  }
 }

--- a/elohim-app/src/app/lamad/components/lamad-layout/lamad-layout.component.css
+++ b/elohim-app/src/app/lamad/components/lamad-layout/lamad-layout.component.css
@@ -2,14 +2,14 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(135deg, #0a0e27 0%, #1a1f3a 100%);
-  color: #e0e6ed;
+  background: linear-gradient(135deg, var(--lamad-bg-primary) 0%, var(--lamad-bg-secondary) 100%);
+  color: var(--lamad-text-secondary);
 }
 
 /* Header */
 .lamad-header {
-  background: rgba(26, 31, 58, 0.95);
-  border-bottom: 2px solid rgba(99, 102, 241, 0.3);
+  background: var(--lamad-surface);
+  border-bottom: 2px solid var(--lamad-border);
   padding: 0.25rem 1rem;
   backdrop-filter: blur(10px);
   position: sticky;
@@ -29,7 +29,7 @@
 .lamad-logo h1 {
   font-size: 0.9rem;
   margin: 0;
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--lamad-accent-gradient);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -52,7 +52,7 @@
 }
 
 .lamad-nav a {
-  color: #cbd5e1;
+  color: var(--lamad-text-secondary);
   text-decoration: none;
   font-weight: 500;
   transition: all 0.2s;
@@ -63,12 +63,12 @@
 }
 
 .lamad-nav a:hover {
-  color: #6366f1;
+  color: var(--lamad-accent-primary);
   background: rgba(99, 102, 241, 0.1);
 }
 
 .lamad-nav a.active {
-  color: #6366f1;
+  color: var(--lamad-accent-primary);
   background: rgba(99, 102, 241, 0.15);
 }
 
@@ -89,13 +89,13 @@
   height: 1.75rem;
   border-radius: 0.25rem;
   background: rgba(99, 102, 241, 0.1);
-  border: 1px solid rgba(99, 102, 241, 0.3);
+  border: 1px solid var(--lamad-border);
   box-shadow: none;
 }
 
 .toolbar-theme-toggle ::ng-deep .theme-toggle:hover {
   background: rgba(99, 102, 241, 0.2);
-  border-color: rgba(99, 102, 241, 0.5);
+  border-color: var(--lamad-border-hover);
   transform: none;
   box-shadow: none;
 }
@@ -130,10 +130,10 @@
 .search-input {
   flex: 1;
   padding: 0.25rem 0.5rem;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(99, 102, 241, 0.3);
+  background: var(--lamad-bg-secondary);
+  border: 1px solid var(--lamad-border);
   border-radius: 0.25rem;
-  color: #e0e6ed;
+  color: var(--lamad-text-secondary);
   font-size: 0.8rem;
   transition: all 0.2s;
   line-height: 1;
@@ -142,17 +142,17 @@
 
 .search-input:focus {
   outline: none;
-  border-color: #6366f1;
+  border-color: var(--lamad-accent-primary);
   box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.1);
 }
 
 .search-input::placeholder {
-  color: #64748b;
+  color: var(--lamad-text-muted);
 }
 
 .search-button {
   padding: 0.25rem 0.5rem;
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--lamad-accent-gradient);
   border: none;
   border-radius: 0.25rem;
   color: white;
@@ -182,7 +182,7 @@
   width: 50px;
   height: 50px;
   border: 4px solid rgba(99, 102, 241, 0.1);
-  border-top-color: #6366f1;
+  border-top-color: var(--lamad-accent-primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
 }
@@ -202,11 +202,11 @@
 
 /* Footer */
 .lamad-footer {
-  background: rgba(15, 23, 42, 0.8);
-  border-top: 1px solid rgba(99, 102, 241, 0.2);
+  background: var(--lamad-surface);
+  border-top: 1px solid var(--lamad-border);
   padding: 1.5rem 2rem;
   text-align: center;
-  color: #64748b;
+  color: var(--lamad-text-muted);
   font-size: 0.875rem;
 }
 

--- a/elohim-app/src/styles.css
+++ b/elohim-app/src/styles.css
@@ -28,6 +28,29 @@
     --tech-bright: rgba(127, 203, 238, 0.8);
     --earthy-orange: rgb(217, 124, 43);
     --earthy-orange-light: rgba(217, 124, 43, 0.8);
+
+    /* Lamad Learning Platform - Clean Professional Theme (Dark Mode Default) */
+    --lamad-bg-primary: #0f172a;
+    --lamad-bg-secondary: #1e293b;
+    --lamad-bg-tertiary: #334155;
+    --lamad-surface: rgba(30, 41, 59, 0.8);
+    --lamad-surface-hover: rgba(51, 65, 85, 0.9);
+
+    --lamad-text-primary: #f1f5f9;
+    --lamad-text-secondary: #cbd5e1;
+    --lamad-text-tertiary: #94a3b8;
+    --lamad-text-muted: #64748b;
+
+    --lamad-border: rgba(148, 163, 184, 0.2);
+    --lamad-border-hover: rgba(148, 163, 184, 0.4);
+
+    --lamad-accent-primary: #6366f1;
+    --lamad-accent-secondary: #8b5cf6;
+    --lamad-accent-gradient: linear-gradient(135deg, #6366f1, #8b5cf6);
+
+    --lamad-success: #10b981;
+    --lamad-warning: #f59e0b;
+    --lamad-info: #3b82f6;
 }
 
 /* Light Theme - Activates based on device preference */
@@ -54,6 +77,29 @@
         --tech-bright: rgba(15, 85, 150, 0.95);
         --earthy-orange: rgb(175, 85, 30);
         --earthy-orange-light: rgba(175, 85, 30, 0.8);
+
+        /* Lamad Learning Platform - Clean Professional Theme (Light Mode) */
+        --lamad-bg-primary: #ffffff;
+        --lamad-bg-secondary: #f8fafc;
+        --lamad-bg-tertiary: #f1f5f9;
+        --lamad-surface: rgba(255, 255, 255, 0.95);
+        --lamad-surface-hover: rgba(248, 250, 252, 1);
+
+        --lamad-text-primary: #0f172a;
+        --lamad-text-secondary: #334155;
+        --lamad-text-tertiary: #475569;
+        --lamad-text-muted: #64748b;
+
+        --lamad-border: rgba(15, 23, 42, 0.15);
+        --lamad-border-hover: rgba(15, 23, 42, 0.3);
+
+        --lamad-accent-primary: #4f46e5;
+        --lamad-accent-secondary: #7c3aed;
+        --lamad-accent-gradient: linear-gradient(135deg, #4f46e5, #7c3aed);
+
+        --lamad-success: #059669;
+        --lamad-warning: #d97706;
+        --lamad-info: #2563eb;
     }
 }
 
@@ -407,6 +453,29 @@ body[data-theme="light"] {
     --tech-bright: rgba(1, 87, 155, 0.9);
     --earthy-orange: rgb(230, 81, 0);
     --earthy-orange-light: rgba(230, 81, 0, 0.8);
+
+    /* Lamad Learning Platform - Clean Professional Theme (Light Mode) */
+    --lamad-bg-primary: #ffffff;
+    --lamad-bg-secondary: #f8fafc;
+    --lamad-bg-tertiary: #f1f5f9;
+    --lamad-surface: rgba(255, 255, 255, 0.95);
+    --lamad-surface-hover: rgba(248, 250, 252, 1);
+
+    --lamad-text-primary: #0f172a;
+    --lamad-text-secondary: #334155;
+    --lamad-text-tertiary: #475569;
+    --lamad-text-muted: #64748b;
+
+    --lamad-border: rgba(15, 23, 42, 0.15);
+    --lamad-border-hover: rgba(15, 23, 42, 0.3);
+
+    --lamad-accent-primary: #4f46e5;
+    --lamad-accent-secondary: #7c3aed;
+    --lamad-accent-gradient: linear-gradient(135deg, #4f46e5, #7c3aed);
+
+    --lamad-success: #059669;
+    --lamad-warning: #d97706;
+    --lamad-info: #2563eb;
 }
 
 body[data-theme="light"]::before {
@@ -472,6 +541,29 @@ body[data-theme="dark"] {
     --tech-bright: rgba(127, 203, 238, 0.8);
     --earthy-orange: rgb(217, 124, 43);
     --earthy-orange-light: rgba(217, 124, 43, 0.8);
+
+    /* Lamad Learning Platform - Clean Professional Theme (Dark Mode) */
+    --lamad-bg-primary: #0f172a;
+    --lamad-bg-secondary: #1e293b;
+    --lamad-bg-tertiary: #334155;
+    --lamad-surface: rgba(30, 41, 59, 0.8);
+    --lamad-surface-hover: rgba(51, 65, 85, 0.9);
+
+    --lamad-text-primary: #f1f5f9;
+    --lamad-text-secondary: #cbd5e1;
+    --lamad-text-tertiary: #94a3b8;
+    --lamad-text-muted: #64748b;
+
+    --lamad-border: rgba(148, 163, 184, 0.2);
+    --lamad-border-hover: rgba(148, 163, 184, 0.4);
+
+    --lamad-accent-primary: #6366f1;
+    --lamad-accent-secondary: #8b5cf6;
+    --lamad-accent-gradient: linear-gradient(135deg, #6366f1, #8b5cf6);
+
+    --lamad-success: #10b981;
+    --lamad-warning: #f59e0b;
+    --lamad-info: #3b82f6;
 }
 
 body[data-theme="dark"]::before {


### PR DESCRIPTION
- Added CSS variables for lamad light and dark themes in styles.css
- Updated lamad-layout.component.css to use theme variables
- Updated lamad-home.component.css with expanded, readable CSS using theme variables
- Updated content-viewer.component.css to fix light text on light background issue
- Ensured proper contrast ratios in both light and dark modes
- Theme now cleanly switches between light/dark modes using existing theme toggle
- Design is clean and professional, similar to Khan Academy 2019 dashboard style