### PR TITLE
Fix broken navigation links in /lamad feature

### DIFF
--- a/elohim-app/src/app/lamad/components/content-viewer/content-viewer.component.ts
+++ b/elohim-app/src/app/lamad/components/content-viewer/content-viewer.component.ts
@@ -128,14 +128,14 @@ export class ContentViewerComponent implements OnInit, OnDestroy {
    * Navigate to related content
    */
   viewRelatedContent(node: ContentNode): void {
-    this.router.navigate(['/docs/content', node.id]);
+    this.router.navigate(['/lamad/content', node.id]);
   }
 
   /**
    * Navigate back to mission map
    */
   backToMap(): void {
-    this.router.navigate(['/docs/map']);
+    this.router.navigate(['/lamad/map']);
   }
 
   /**

--- a/elohim-app/src/app/lamad/components/epic-viewer/epic-viewer.component.html
+++ b/elohim-app/src/app/lamad/components/epic-viewer/epic-viewer.component.html
@@ -44,7 +44,7 @@
         <div class="related-list">
           <a
             *ngFor="let feature of relatedFeatures"
-            [routerLink]="['/docs/feature', feature.id]"
+            [routerLink]="['/lamad/content', feature.id]"
             class="related-item"
           >
             <span class="related-icon">⚡</span>

--- a/elohim-app/src/app/lamad/components/feature-viewer/feature-viewer.component.ts
+++ b/elohim-app/src/app/lamad/components/feature-viewer/feature-viewer.component.ts
@@ -29,7 +29,7 @@ import { FeatureNode, ScenarioNode, EpicNode } from '../../models';
         <h2>Scenarios</h2>
         <div class="scenario-list">
           <a *ngFor="let scenario of scenarios"
-             [routerLink]="['/docs/scenario', scenario.id]"
+             [routerLink]="['/lamad/content', scenario.id]"
              class="scenario-card">
             <h3>{{scenario.title}}</h3>
             <div class="step-count">{{scenario.steps.length}} steps</div>
@@ -41,7 +41,7 @@ import { FeatureNode, ScenarioNode, EpicNode } from '../../models';
         <h2>Related Epics</h2>
         <div class="epic-list">
           <a *ngFor="let epic of relatedEpics"
-             [routerLink]="['/docs/epic', epic.id]"
+             [routerLink]="['/lamad/content', epic.id]"
              class="epic-link">
             📖 {{epic.title}}
           </a>

--- a/elohim-app/src/app/lamad/components/module-viewer/module-viewer.component.html
+++ b/elohim-app/src/app/lamad/components/module-viewer/module-viewer.component.html
@@ -47,10 +47,10 @@
   <!-- Navigation Footer -->
   <div class="module-footer" *ngIf="epic || feature">
     <div class="footer-links">
-      <a *ngIf="epic" [routerLink]="['/docs/epic', epic.id]" class="footer-link">
+      <a *ngIf="epic" [routerLink]="['/lamad/content', epic.id]" class="footer-link">
         📖 View Full Epic
       </a>
-      <a *ngIf="feature" [routerLink]="['/docs/feature', feature.id]" class="footer-link">
+      <a *ngIf="feature" [routerLink]="['/lamad/content', feature.id]" class="footer-link">
         🧪 View All Scenarios
       </a>
     </div>

--- a/elohim-app/src/app/lamad/components/scenario-detail/scenario-detail.component.ts
+++ b/elohim-app/src/app/lamad/components/scenario-detail/scenario-detail.component.ts
@@ -13,7 +13,7 @@ import { ScenarioNode, FeatureNode } from '../../models';
       <div class="scenario-header">
         <div class="breadcrumb">
           <a routerLink="/lamad">Home</a> /
-          <a [routerLink]="['/docs/feature', feature.id]" *ngIf="feature">{{feature.title}}</a> /
+          <a [routerLink]="['/lamad/content', feature.id]" *ngIf="feature">{{feature.title}}</a> /
           <span>Scenario</span>
         </div>
         <h1 class="scenario-title">{{scenario.title}}</h1>

--- a/elohim-app/src/app/lamad/components/search/search.component.ts
+++ b/elohim-app/src/app/lamad/components/search/search.component.ts
@@ -81,7 +81,7 @@ export class SearchComponent implements OnInit {
   }
 
   getNodeRoute(node: DocumentNode): string[] {
-    return ['/docs', node.type, node.id];
+    return ['/lamad/content', node.id];
   }
 
   getNodeTypeIcon(type: string): string {


### PR DESCRIPTION
Updated all navigation paths from incorrect /docs/* routes to correct /lamad/* routes:
- content-viewer: Fixed "Back to Map" button (/docs/map -> /lamad/map) and related content links
- search: Fixed node route generation to use /lamad/content/:id
- feature-viewer: Fixed scenario and epic links
- epic-viewer: Fixed related features links
- scenario-detail: Fixed feature breadcrumb link
- module-viewer: Fixed epic and feature footer links

All content now properly routes through /lamad/content/:id as defined in lamad.routes.ts