### PR TITLE
Fix 404 error on page refresh for SPA routes like /lamad

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -23,8 +23,8 @@ FROM nginx:alpine
 # Copy built application from builder stage
 COPY --from=builder /app/dist/elohim-app/browser /usr/share/nginx/html
 
-# Copy nginx configuration (optional - using default nginx config)
-# COPY nginx.conf /etc/nginx/nginx.conf
+# Copy nginx configuration for SPA routing
+COPY images/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose port 80
 EXPOSE 80

--- a/images/nginx.conf
+++ b/images/nginx.conf
@@ -1,0 +1,35 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Enable gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json application/javascript;
+
+    # SPA routing - serve index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(?:css|js|jpg|jpeg|gif|png|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Don't cache index.html
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        expires 0;
+    }
+
+    # Don't cache config.json
+    location = /assets/config.json {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        expires 0;
+    }
+}


### PR DESCRIPTION
Added nginx configuration to properly handle Single Page Application routing. The default nginx config doesn't serve index.html for client-side routes, causing 404 errors on page refresh. This fix uses try_files directive to serve index.html for all routes, allowing the Angular router to handle them.

Changes:
- Created images/nginx.conf with SPA routing configuration
- Updated Dockerfile to copy nginx.conf to container
- Added caching rules for static assets
- Disabled caching for index.html and config.json to ensure fresh content