### PR TITLE
Fix Docker build context to include nginx.conf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -310,6 +310,7 @@ BRANCH_NAME=${env.BRANCH_NAME}"""
                                 mkdir -p /tmp/build-context
                                 cp -r elohim-app /tmp/build-context/
                                 cp images/Dockerfile /tmp/build-context/
+                                cp images/nginx.conf /tmp/build-context/
                                 
                                 # Build image
                                 cd /tmp/build-context

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -24,7 +24,7 @@ FROM nginx:alpine
 COPY --from=builder /app/dist/elohim-app/browser /usr/share/nginx/html
 
 # Copy nginx configuration for SPA routing
-COPY images/nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose port 80
 EXPOSE 80


### PR DESCRIPTION
The previous commit added nginx.conf but the Jenkinsfile wasn't copying it to the build context, causing the Docker build to fail with "nginx.conf not found".

Changes:
- Updated Jenkinsfile to copy nginx.conf into the build context
- Updated Dockerfile COPY path from images/nginx.conf to nginx.conf to match the new build context structure