### PR TITLE
Fix duplicate CSS selectors in lamad-home component

### DIFF
--- a/elohim-app/src/app/lamad/components/lamad-home/lamad-home.component.css
+++ b/elohim-app/src/app/lamad/components/lamad-home/lamad-home.component.css
@@ -361,23 +361,6 @@
   filter: brightness(1.2);
 }
 
-/* Affinity Colors */
-.affinity-unseen {
-  background-color: rgba(148, 163, 184, 0.8); /* Slate */
-}
-
-.affinity-low {
-  background-color: #fca5a5; /* Red/Orange tint */
-}
-
-.affinity-medium {
-  background-color: #fbbf24; /* Yellow/Gold */
-}
-
-.affinity-high {
-  background-color: #34d399; /* Green */
-}
-
 /* Home Placeholder (Epic Grid) */
 .home-placeholder {
   padding: 3rem;


### PR DESCRIPTION
Remove duplicate affinity color selector definitions that were causing linting errors. The duplicates at lines 365-378 have been removed, keeping the more complete definitions with box-shadow effects at lines 498-515.

Fixed selectors:
- .affinity-unseen (was at line 365 and 515)
- .affinity-low (was at line 369 and 519)
- .affinity-medium (was at line 373 and 524)
- .affinity-high (was at line 377 and 529)