### PR TITLE
Fix export conflicts in lamad models index

### DIFF
--- a/elohim-app/src/app/lamad/models/index.ts
+++ b/elohim-app/src/app/lamad/models/index.ts
@@ -4,11 +4,23 @@
 
 export * from './document-node.model';
 export * from './epic-node.model';
-export * from './feature-node.model';
-export * from './scenario-node.model';
-export * from './node-relationship.model';
 export * from './document-graph.model';
-
-// New generic content models
-export * from './content-node.model';
 export * from './lamad-node-types';
+
+// Export from node-relationship.model (keep the primary RelationshipType)
+export * from './node-relationship.model';
+
+// Export from feature-node.model (excluding ScenarioExamples to avoid conflict)
+export type { FeatureNode, FeatureCategory } from './feature-node.model';
+
+// Export from scenario-node.model (includes ScenarioExamples)
+export * from './scenario-node.model';
+
+// Export from content-node.model (excluding RelationshipType alias to avoid conflict)
+export type {
+  ContentNode,
+  ContentMetadata,
+  ContentFormat,
+  ContentRelationship
+} from './content-node.model';
+export { ContentRelationshipType, ContentFormatType } from './content-node.model';


### PR DESCRIPTION
Resolved TypeScript module conflicts after dev branch merge:

- Fix RelationshipType duplicate export conflict
  - Keep primary RelationshipType from node-relationship.model
  - Export ContentRelationshipType separately from content-node.model
  - Remove conflicting RelationshipType alias

- Fix ScenarioExamples duplicate export conflict
  - Export ScenarioExamples from scenario-node.model (primary)
  - Use explicit type export for FeatureNode to exclude duplicate

- Improve export organization
  - Use explicit type exports where conflicts exist
  - Keep wildcard exports for non-conflicting modules
  - Add comments explaining export strategy

This fixes the compilation errors:
- TS2308: Module has already exported a member
- TS2305: Module has no exported member

Note: Additional type system refactoring needed for full test suite pass. The codebase has parallel type systems (DocumentNode vs ContentNode) that need reconciliation in components and services.