### PR TITLE
Fix SonarQube code quality issues

### DIFF
--- a/elohim-app/src/app/lamad/components/profile-page/profile-page.component.ts
+++ b/elohim-app/src/app/lamad/components/profile-page/profile-page.component.ts
@@ -7,8 +7,8 @@ import { takeUntil } from 'rxjs/operators';
 import { SessionHumanService } from '../../services/session-human.service';
 import { ContentMasteryService } from '../../services/content-mastery.service';
 import { SessionHuman, SessionActivity, SessionPathProgress } from '../../models/session-human.model';
-import { MasteryStats, ContentMastery } from '../../models/content-mastery.model';
-import { BloomMasteryLevel, BLOOM_LEVEL_VALUES } from '../../models/agent.model';
+import { MasteryStats } from '../../models/content-mastery.model';
+import { BloomMasteryLevel } from '../../models/agent.model';
 
 /**
  * ProfilePageComponent - Session Human profile management.

--- a/elohim-app/src/app/lamad/models/content-node.model.ts
+++ b/elohim-app/src/app/lamad/models/content-node.model.ts
@@ -29,13 +29,7 @@
 
 import {
   type ReachLevel,
-  type GovernanceLayer,
   type GeographicContext,
-  type Attestation,
-  type AttestationStatus,
-  type Timestamps,
-  type Identifiable,
-  REACH_LEVEL_VALUES,
 } from './protocol-core.model';
 import type { Place } from './place.model';
 import { JsonLdMetadata } from './json-ld.model';

--- a/elohim-app/src/app/lamad/models/human-node.model.ts
+++ b/elohim-app/src/app/lamad/models/human-node.model.ts
@@ -45,12 +45,6 @@ import {
   type GovernanceLayer,
   type ReachLevel,
   type GeographicContext,
-  type ProtocolAgent,
-  type Attestation,
-  type Timestamps,
-  type Identifiable,
-  INTIMACY_LEVEL_VALUES,
-  hasMinimumIntimacy,
 } from './protocol-core.model';
 
 // Re-export core types for convenience

--- a/elohim-app/src/app/lamad/models/rea-bridge.model.ts
+++ b/elohim-app/src/app/lamad/models/rea-bridge.model.ts
@@ -44,12 +44,7 @@
 
 import {
   type TokenType,
-  type TokenDecayRate,
   type GovernanceLayer,
-  type Attestation,
-  type AttestationStatus,
-  type ProtocolAgent,
-  type AgentType,
 } from './protocol-core.model';
 
 // ============================================================================

--- a/elohim-app/src/app/lamad/services/content-mastery.service.ts
+++ b/elohim-app/src/app/lamad/services/content-mastery.service.ts
@@ -16,15 +16,11 @@ import {
 } from '../models/content-mastery.model';
 import {
   BloomMasteryLevel,
-  BLOOM_LEVEL_VALUES,
-  ATTESTATION_GATE_LEVEL,
   isAboveGate,
   compareMasteryLevels,
 } from '../models/agent.model';
 import {
   MasteryRecordContent,
-  LamadEntryType,
-  LamadLinkType,
   SourceChainEntry,
 } from '../models/source-chain.model';
 
@@ -415,7 +411,7 @@ export class ContentMasteryService {
    * Refresh all freshness values in cache.
    */
   refreshAllFreshness(): void {
-    for (const [contentId, mastery] of this.masteryCache) {
+    for (const [, mastery] of this.masteryCache) {
       mastery.freshness = this.computeFreshness(mastery);
       mastery.needsRefresh = mastery.freshness < FRESHNESS_THRESHOLDS.FRESH;
 

--- a/elohim-app/src/app/lamad/services/human-consent.service.ts
+++ b/elohim-app/src/app/lamad/services/human-consent.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Observable, of, throwError, BehaviorSubject } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 
 import { LocalSourceChainService } from './local-source-chain.service';
 import { SessionHumanService } from './session-human.service';
@@ -8,14 +8,10 @@ import {
   HumanConsent,
   IntimacyLevel,
   ConsentState,
-  ConsentStateChange,
-  ConsentRequest,
-  ConsentResponse,
   ElevationRequest,
   hasMinimumIntimacy,
   isConsentActive,
   canElevate,
-  getNextIntimacyLevel,
 } from '../models/human-consent.model';
 import { HumanConsentContent } from '../models/source-chain.model';
 import type { LearningPath, PathVisibility } from '../models/learning-path.model';
@@ -37,12 +33,12 @@ import type { LearningPath, PathVisibility } from '../models/learning-path.model
  */
 @Injectable({ providedIn: 'root' })
 export class HumanConsentService {
-  private consentsSubject = new BehaviorSubject<HumanConsent[]>([]);
+  private readonly consentsSubject = new BehaviorSubject<HumanConsent[]>([]);
   public consents$ = this.consentsSubject.asObservable();
 
   constructor(
-    private sourceChain: LocalSourceChainService,
-    private sessionHuman: SessionHumanService
+    private readonly sourceChain: LocalSourceChainService,
+    private readonly sessionHuman: SessionHumanService
   ) {}
 
   // =========================================================================

--- a/elohim-app/src/app/lamad/services/local-source-chain.service.ts
+++ b/elohim-app/src/app/lamad/services/local-source-chain.service.ts
@@ -355,7 +355,7 @@ export class LocalSourceChainService {
     propertyValue: unknown
   ): SourceChainEntry<T>[] {
     return this.getEntriesByType<T>(entryType).filter(
-      entry => (entry.content as T)[propertyName] === propertyValue
+      entry => entry.content[propertyName] === propertyValue
     );
   }
 

--- a/elohim-app/src/app/lamad/services/path-negotiation.service.ts
+++ b/elohim-app/src/app/lamad/services/path-negotiation.service.ts
@@ -14,14 +14,13 @@ import {
   NegotiationResponse,
   PathAcceptance,
   AffinityAnalysis,
-  AffinityNode,
   ProposedPathStructure,
   isNegotiationActive,
   isNegotiationResolved,
 } from '../models/path-negotiation.model';
 import { hasMinimumIntimacy } from '../models/human-consent.model';
-import { PathNegotiationContent, NegotiationMessageContent } from '../models/source-chain.model';
-import type { LearningPath, PathStep } from '../models/learning-path.model';
+import { PathNegotiationContent } from '../models/source-chain.model';
+ from '../models/learning-path.model';
 
 /**
  * PathNegotiationService - Placeholder for Elohim-to-Elohim path negotiation.
@@ -40,13 +39,13 @@ import type { LearningPath, PathStep } from '../models/learning-path.model';
  */
 @Injectable({ providedIn: 'root' })
 export class PathNegotiationService {
-  private negotiationsSubject = new BehaviorSubject<PathNegotiation[]>([]);
+  private readonly negotiationsSubject = new BehaviorSubject<PathNegotiation[]>([]);
   public negotiations$ = this.negotiationsSubject.asObservable();
 
   constructor(
-    private sourceChain: LocalSourceChainService,
-    private consentService: HumanConsentService,
-    private affinityService: AffinityTrackingService
+    private readonly sourceChain: LocalSourceChainService,
+    private readonly consentService: HumanConsentService,
+    private readonly affinityService: AffinityTrackingService
   ) {}
 
   // =========================================================================


### PR DESCRIPTION
This commit addresses multiple SonarQube code quality issues:

1. Remove unused imports across multiple files:
   - content-node.model.ts: Remove GovernanceLayer, Attestation, AttestationStatus, Timestamps, Identifiable, REACH_LEVEL_VALUES
   - rea-bridge.model.ts: Remove TokenDecayRate, Attestation, AttestationStatus, ProtocolAgent, AgentType
   - human-node.model.ts: Remove ProtocolAgent, Attestation, Timestamps, Identifiable, INTIMACY_LEVEL_VALUES, hasMinimumIntimacy
   - human-consent.service.ts: Remove map operator, ConsentStateChange, ConsentRequest, ConsentResponse, getNextIntimacyLevel
   - path-negotiation.service.ts: Remove AffinityNode, NegotiationMessageContent, LearningPath, PathStep
   - profile-page.component.ts: Remove ContentMastery, BLOOM_LEVEL_VALUES
   - content-mastery.service.ts: Remove BLOOM_LEVEL_VALUES, ATTESTATION_GATE_LEVEL, LamadEntryType, LamadLinkType

2. Add readonly modifiers to service dependencies:
   - human-consent.service.ts: Mark consentsSubject, sourceChain, sessionHuman as readonly
   - path-negotiation.service.ts: Mark negotiationsSubject, sourceChain, consentService, affinityService as readonly

3. Remove code smells:
   - content-mastery.service.ts: Remove unused contentId variable in for loop
   - local-source-chain.service.ts: Remove unnecessary type assertion

These changes improve code maintainability and reduce technical debt.