### PR TITLE
Fix linting issues in dom-interaction service and access-control helper

### DIFF
--- a/elohim-app/src/app/services/dom-interaction.service.ts
+++ b/elohim-app/src/app/services/dom-interaction.service.ts
@@ -7,7 +7,7 @@ import { Injectable, ElementRef, Renderer2, RendererFactory2 } from '@angular/co
   providedIn: 'root'
 })
 export class DomInteractionService {
-  private renderer: Renderer2;
+  private readonly renderer: Renderer2;
 
   constructor(rendererFactory: RendererFactory2) {
     this.renderer = rendererFactory.createRenderer(null, null);

--- a/elohim-app/src/app/shared/utils/access-control.helper.ts
+++ b/elohim-app/src/app/shared/utils/access-control.helper.ts
@@ -23,7 +23,7 @@ export function canView(entity: AccessControlEntity, currentAgentId: string): bo
   }
 
   // Owner can always view
-  const ownerId = entity.ownerId || entity.extendedBy;
+  const ownerId = entity.ownerId ?? entity.extendedBy;
   if (ownerId === currentAgentId) {
     return true;
   }
@@ -49,7 +49,7 @@ export function canView(entity: AccessControlEntity, currentAgentId: string): bo
  */
 export function canEdit(entity: AccessControlEntity, currentAgentId: string): boolean {
   // Owner can always edit
-  const ownerId = entity.ownerId || entity.extendedBy;
+  const ownerId = entity.ownerId ?? entity.extendedBy;
   if (ownerId === currentAgentId) {
     return true;
   }
@@ -72,7 +72,7 @@ export function canEdit(entity: AccessControlEntity, currentAgentId: string): bo
  */
 export function canDelete(entity: AccessControlEntity, currentAgentId: string): boolean {
   // Only owner can delete
-  const ownerId = entity.ownerId || entity.extendedBy;
+  const ownerId = entity.ownerId ?? entity.extendedBy;
   if (ownerId === currentAgentId) {
     return true;
   }


### PR DESCRIPTION
Fixed 4 linting issues:
1. DomInteractionService: Mark renderer as readonly (never reassigned) 2-4. AccessControlHelper: Replace logical OR (||) with nullish coalescing (??)
   in canView, canEdit, and canDelete functions for safer type handling

These changes improve code quality and maintainability by:
- Preventing accidental reassignment of the renderer
- Using nullish coalescing for better handling of falsy values (empty strings would be preserved instead of falling back)