### PR TITLE
fix: prevent HolochainClientService callZome timeout in disconnected …

### DIFF
--- a/elohim-app/src/app/elohim/services/holochain-client.service.ts
+++ b/elohim-app/src/app/elohim/services/holochain-client.service.ts
@@ -414,6 +414,14 @@ export class HolochainClientService {
   async callZome<T>(input: ZomeCallInput): Promise<ZomeCallResult<T>> {
     let { appWs, cellId, state } = this.connectionSignal();
 
+    // Return immediately if in disconnected or error state
+    if (state === 'disconnected' || state === 'error') {
+      return {
+        success: false,
+        error: 'Not connected to Holochain conductor',
+      };
+    }
+
     // If not connected yet, wait for connection (only if actively connecting)
     if (!appWs || !cellId) {
       if (state === 'connecting' || state === 'authenticating') {


### PR DESCRIPTION
…state

The callZome method was timing out in tests when called in disconnected state. Added early return for disconnected/error states to immediately return an error instead of waiting for a connection that will never happen.

This fixes the test timeout issue where async functions didn't complete within the 5000ms Jasmine timeout interval.

Fixes test: "HolochainClientService callZome should return error when not connected"