### PR TITLE
fix: configure alpha deployment to use correct environment and holoch…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -239,15 +239,24 @@ BRANCH_NAME=${env.BRANCH_NAME}"""
                                 echo 'Building Angular application'
                                 echo "Using git hash: ${GIT_COMMIT_HASH}"
                                 echo "Using image tag: ${IMAGE_TAG}"
-                                
+
                                 // Replace placeholders
                                 sh """
                                     sed -i "s/GIT_HASH_PLACEHOLDER/${GIT_COMMIT_HASH}/g" src/environments/environment.prod.ts
                                     sed -i "s/GIT_HASH_PLACEHOLDER/${GIT_COMMIT_HASH}/g" src/environments/environment.staging.ts
                                     sed -i "s/GIT_HASH_PLACEHOLDER/${GIT_COMMIT_HASH}/g" src/environments/environment.alpha.ts
                                 """
-                                
-                                sh 'npm run build'
+
+                                // Determine build configuration based on branch
+                                def buildConfig = 'production'
+                                if (env.BRANCH_NAME == 'staging' || env.BRANCH_NAME ==~ /staging-.+/) {
+                                    buildConfig = 'staging'
+                                } else if (env.BRANCH_NAME == 'dev' || env.BRANCH_NAME ==~ /feat-.+/ || env.BRANCH_NAME ==~ /claude\/.+/ || env.BRANCH_NAME.contains('alpha')) {
+                                    buildConfig = 'alpha'
+                                }
+
+                                echo "Building with configuration: ${buildConfig}"
+                                sh "npm run build -- --configuration=${buildConfig}"
                                 sh 'ls -la dist/'
                             }
                         }

--- a/elohim-app/src/environments/environment.alpha.ts
+++ b/elohim-app/src/environments/environment.alpha.ts
@@ -6,10 +6,10 @@ export const environment = {
   environment: 'alpha',
   gitHash: 'GIT_HASH_PLACEHOLDER',
   // Holochain Edge Node configuration
-  // Single proxy URL handles admin operations with authentication
+  // Alpha uses dev instance until alpha holochain is deployed
   holochain: {
-    adminUrl: 'wss://holochain-alpha.elohim.host',
-    appUrl: 'wss://holochain-alpha.elohim.host',
-    proxyApiKey: 'alpha-elohim-auth-2024',
+    adminUrl: 'wss://holochain-dev.elohim.host',
+    appUrl: 'wss://holochain-dev.elohim.host',
+    proxyApiKey: 'dev-elohim-auth-2024',
   }
 };


### PR DESCRIPTION
…ain instance

1. Updated alpha environment to use dev holochain instance
   - Alpha holochain not yet deployed, using dev as interim
   - Changed from holochain-alpha.elohim.host to holochain-dev.elohim.host

2. Fixed Jenkinsfile to use correct Angular build configuration
   - Production builds: --configuration=production
   - Staging builds: --configuration=staging
   - Dev/alpha/feature builds: --configuration=alpha
   - Previously all builds used production config by default

This fixes the issue where alpha.elohim.host was trying to connect to the non-existent wss://holochain.elohim.host instead of the dev instance.