### PR TITLE
Fix dev pipeline: Reduce Jenkinsfile method size to resolve compilation error

### DIFF
--- a/jenkins/scripts/build-image.sh
+++ b/jenkins/scripts/build-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_TAG=$1
+GIT_COMMIT_HASH=$2
+BRANCH_NAME=$3
+
+# Verify BuildKit
+buildctl --addr unix:///run/buildkit/buildkitd.sock debug workers > /dev/null
+
+# Create build context
+mkdir -p /tmp/build-context
+cp -r elohim-app /tmp/build-context/
+cp images/Dockerfile /tmp/build-context/
+cp images/nginx.conf /tmp/build-context/
+
+# Build image
+cd /tmp/build-context
+BUILDKIT_HOST=unix:///run/buildkit/buildkitd.sock \
+  nerdctl -n k8s.io build -t elohim-app:${IMAGE_TAG} -f Dockerfile .
+
+# Additional tags
+nerdctl -n k8s.io tag elohim-app:${IMAGE_TAG} elohim-app:${GIT_COMMIT_HASH}
+
+if [ "${BRANCH_NAME}" = "main" ]; then
+    nerdctl -n k8s.io tag elohim-app:${IMAGE_TAG} elohim-app:latest
+fi

--- a/jenkins/scripts/build-ui-playground-image.sh
+++ b/jenkins/scripts/build-ui-playground-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_TAG=$1
+GIT_COMMIT_HASH=$2
+BRANCH_NAME=$3
+
+# Verify BuildKit
+buildctl --addr unix:///run/buildkit/buildkitd.sock debug workers > /dev/null
+
+# Create build context
+mkdir -p /tmp/build-context-playground
+cp -r elohim-library /tmp/build-context-playground/
+cp images/Dockerfile.ui-playground /tmp/build-context-playground/Dockerfile
+cp images/nginx-ui-playground.conf /tmp/build-context-playground/
+
+# Build image
+cd /tmp/build-context-playground
+BUILDKIT_HOST=unix:///run/buildkit/buildkitd.sock \
+  nerdctl -n k8s.io build -t elohim-ui-playground:${IMAGE_TAG} -f Dockerfile .
+
+# Additional tags
+nerdctl -n k8s.io tag elohim-ui-playground:${IMAGE_TAG} elohim-ui-playground:${GIT_COMMIT_HASH}
+
+if [ "${BRANCH_NAME}" = "main" ]; then
+    nerdctl -n k8s.io tag elohim-ui-playground:${IMAGE_TAG} elohim-ui-playground:latest
+fi

--- a/jenkins/scripts/cleanup-images.sh
+++ b/jenkins/scripts/cleanup-images.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_TAG=$1
+GIT_COMMIT_HASH=$2
+BRANCH_NAME=$3
+
+echo 'Cleaning up Docker images...'
+nerdctl -n k8s.io rmi elohim-app:${IMAGE_TAG} || true
+nerdctl -n k8s.io rmi elohim-app:${GIT_COMMIT_HASH} || true
+nerdctl -n k8s.io rmi harbor.ethosengine.com/ethosengine/elohim-site:${IMAGE_TAG} || true
+nerdctl -n k8s.io rmi harbor.ethosengine.com/ethosengine/elohim-site:${GIT_COMMIT_HASH} || true
+nerdctl -n k8s.io rmi elohim-ui-playground:${IMAGE_TAG} || true
+nerdctl -n k8s.io rmi elohim-ui-playground:${GIT_COMMIT_HASH} || true
+nerdctl -n k8s.io rmi harbor.ethosengine.com/ethosengine/elohim-ui-playground:${IMAGE_TAG} || true
+nerdctl -n k8s.io rmi harbor.ethosengine.com/ethosengine/elohim-ui-playground:${GIT_COMMIT_HASH} || true
+
+if [ "${BRANCH_NAME}" = "main" ]; then
+    nerdctl -n k8s.io rmi elohim-app:latest || true
+    nerdctl -n k8s.io rmi harbor.ethosengine.com/ethosengine/elohim-site:latest || true
+    nerdctl -n k8s.io rmi elohim-ui-playground:latest || true
+    nerdctl -n k8s.io rmi harbor.ethosengine.com/ethosengine/elohim-ui-playground:latest || true
+fi
+
+nerdctl -n k8s.io system prune -af --volumes || true

--- a/jenkins/scripts/harbor-security-scan.sh
+++ b/jenkins/scripts/harbor-security-scan.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_TAG=$1
+
+AUTH_HEADER="Authorization: Basic $(echo -n "$HARBOR_USERNAME:$HARBOR_PASSWORD" | base64)"
+
+# Trigger scan
+wget --post-data="" \
+  --header="accept: application/json" \
+  --header="Content-Type: application/json" \
+  --header="$AUTH_HEADER" \
+  -S -O- \
+  "https://harbor.ethosengine.com/api/v2.0/projects/ethosengine/repositories/elohim-site/artifacts/${IMAGE_TAG}/scan" || \
+echo "Scan request failed"
+
+# Poll for completion
+MAX_ATTEMPTS=24
+ATTEMPT=1
+
+while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+    VULN_DATA=$(wget -q -O- \
+      --header="accept: application/json" \
+      --header="$AUTH_HEADER" \
+      "https://harbor.ethosengine.com/api/v2.0/projects/ethosengine/repositories/elohim-site/artifacts/${IMAGE_TAG}/additions/vulnerabilities" 2>/dev/null || echo "")
+
+    if [ ! -z "$VULN_DATA" ] && echo "$VULN_DATA" | grep -q '"scanner"'; then
+        echo "✅ Scan completed"
+        break
+    fi
+
+    [ $((ATTEMPT % 5)) -eq 0 ] && echo "Waiting for scan (attempt $ATTEMPT/$MAX_ATTEMPTS)..."
+    sleep 10
+    ATTEMPT=$((ATTEMPT + 1))
+done

--- a/jenkins/scripts/push-to-harbor.sh
+++ b/jenkins/scripts/push-to-harbor.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_TAG=$1
+GIT_COMMIT_HASH=$2
+BRANCH_NAME=$3
+
+nerdctl -n k8s.io tag elohim-app:${IMAGE_TAG} harbor.ethosengine.com/ethosengine/elohim-site:${IMAGE_TAG}
+nerdctl -n k8s.io tag elohim-app:${IMAGE_TAG} harbor.ethosengine.com/ethosengine/elohim-site:${GIT_COMMIT_HASH}
+
+nerdctl -n k8s.io push harbor.ethosengine.com/ethosengine/elohim-site:${IMAGE_TAG}
+nerdctl -n k8s.io push harbor.ethosengine.com/ethosengine/elohim-site:${GIT_COMMIT_HASH}
+
+if [ "${BRANCH_NAME}" = "main" ]; then
+    nerdctl -n k8s.io tag elohim-app:${IMAGE_TAG} harbor.ethosengine.com/ethosengine/elohim-site:latest
+    nerdctl -n k8s.io push harbor.ethosengine.com/ethosengine/elohim-site:latest
+fi

--- a/jenkins/scripts/push-ui-playground-to-harbor.sh
+++ b/jenkins/scripts/push-ui-playground-to-harbor.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_TAG=$1
+GIT_COMMIT_HASH=$2
+BRANCH_NAME=$3
+
+nerdctl -n k8s.io tag elohim-ui-playground:${IMAGE_TAG} harbor.ethosengine.com/ethosengine/elohim-ui-playground:${IMAGE_TAG}
+nerdctl -n k8s.io tag elohim-ui-playground:${IMAGE_TAG} harbor.ethosengine.com/ethosengine/elohim-ui-playground:${GIT_COMMIT_HASH}
+
+nerdctl -n k8s.io push harbor.ethosengine.com/ethosengine/elohim-ui-playground:${IMAGE_TAG}
+nerdctl -n k8s.io push harbor.ethosengine.com/ethosengine/elohim-ui-playground:${GIT_COMMIT_HASH}
+
+if [ "${BRANCH_NAME}" = "main" ]; then
+    nerdctl -n k8s.io tag elohim-ui-playground:${IMAGE_TAG} harbor.ethosengine.com/ethosengine/elohim-ui-playground:latest
+    nerdctl -n k8s.io push harbor.ethosengine.com/ethosengine/elohim-ui-playground:latest
+fi

--- a/jenkins/scripts/run-e2e-tests.sh
+++ b/jenkins/scripts/run-e2e-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+BASE_URL=$1
+ENV=$2
+GIT_COMMIT_HASH=$3
+
+export CYPRESS_baseUrl=$BASE_URL
+export CYPRESS_ENV=$ENV
+export CYPRESS_EXPECTED_GIT_HASH=$GIT_COMMIT_HASH
+export NO_COLOR=1
+export DISPLAY=:99
+
+# Start Xvfb
+Xvfb :99 -screen 0 1024x768x24 -ac > /dev/null 2>&1 &
+XVFB_PID=$!
+sleep 2
+
+# Verify Cypress
+npx cypress verify > /dev/null
+mkdir -p cypress/reports
+
+# Run tests
+npx cypress run \
+    --headless \
+    --browser chromium \
+    --spec "cypress/e2e/staging-validation.feature"
+
+# Cleanup
+kill $XVFB_PID 2>/dev/null || true


### PR DESCRIPTION
The Jenkinsfile was exceeding the JVM's 64KB method size limit when compiled
to CPS bytecode, causing build #339 to fail with "Method too large" error.

Changes:
- Extract large shell scripts to separate files in jenkins/scripts/
  - build-image.sh
  - build-ui-playground-image.sh
  - push-to-harbor.sh
  - push-ui-playground-to-harbor.sh
  - harbor-security-scan.sh
  - run-e2e-tests.sh
  - cleanup-images.sh
- Reduce Jenkinsfile from 1110 to 619 lines (44% reduction)
- Remove excessive debug statements
- Simplify post blocks
- Consolidate repetitive code patterns

This refactoring maintains all functionality while ensuring the compiled
CPS method stays within JVM limits.

Fixes: https://jenkins.ethosengine.com/job/elohim/job/dev/339/console