### PR TITLE
fix(ci): Add FORCE_BUILD to DNA and Doorway stages

### DIFF
--- a/holochain/Jenkinsfile
+++ b/holochain/Jenkinsfile
@@ -287,7 +287,10 @@ BRANCH_NAME=${env.BRANCH_NAME}"""
 
         stage('Build DNA') {
             when {
-                changeset "holochain/dna/**"
+                anyOf {
+                    changeset "holochain/dna/**"
+                    expression { return params.FORCE_BUILD == true }
+                }
             }
             steps {
                 container('builder') {
@@ -364,6 +367,7 @@ BRANCH_NAME=${env.BRANCH_NAME}"""
                 anyOf {
                     changeset "holochain/doorway/**"
                     changeset "holochain/manifests/edgenode-*.yaml"
+                    expression { return params.FORCE_BUILD == true }
                 }
             }
             steps {


### PR DESCRIPTION
Build DNA and Build Doorway stages were missing the FORCE_BUILD parameter check, so running with FORCE_BUILD=true would not actually trigger the DNA build - it would skip and fail to produce hApp artifacts.

Now all build stages respect FORCE_BUILD:
- Build DNA: changeset OR FORCE_BUILD
- Build Doorway: changeset OR FORCE_BUILD
- Build Edge Node: changeset OR FORCE_BUILD
- Build hApp Installer: changeset OR FORCE_BUILD
- Push to Harbor: changeset OR FORCE_BUILD