### PR TITLE
fix(happ): Rename role from 'lamad' to 'elohim' for consistency

### DIFF
--- a/holochain/dna/lamad-spike/workdir/happ.yaml
+++ b/holochain/dna/lamad-spike/workdir/happ.yaml
@@ -1,11 +1,12 @@
-# Lamad Spike hApp Manifest
+# Elohim hApp Manifest
 # Rebuilt: 2025-12-14 - fixed getrandom wasm_js issue
+# Updated: 2025-12-25 - renamed role from lamad to elohim for consistency
 ---
 manifest_version: "0"
-name: lamad-spike
-description: "Minimal hApp for testing browser-to-Holochain connectivity"
+name: elohim
+description: "Elohim Protocol hApp"
 roles:
-  - name: lamad
+  - name: elohim
     provisioning:
       strategy: create
       deferred: false


### PR DESCRIPTION
The seeder expects role name 'elohim' but the happ.yaml was using 'lamad'. This caused the seeder to fail with "Role 'elohim' not found in app".

Updated happ.yaml:
- name: lamad-spike -> elohim
- role: lamad -> elohim

This requires the hApp to be rebuilt for the change to take effect.