### PR TITLE
fix(projection-api): Use proxyApiKey instead of apiKey to match inter…

### DIFF
--- a/elohim-app/src/app/elohim/services/projection-api.service.ts
+++ b/elohim-app/src/app/elohim/services/projection-api.service.ts
@@ -103,7 +103,7 @@ export class ProjectionAPIService {
 
   /** API key for authenticated requests */
   private get apiKey(): string | undefined {
-    return environment.holochain?.apiKey;
+    return environment.holochain?.proxyApiKey;
   }
 
   /** Build URL with optional API key */


### PR DESCRIPTION
…face definition

Fixes TypeScript compilation error:
TS2339: Property 'apiKey' does not exist on type 'HolochainEnvironmentConfig'

The HolochainEnvironmentConfig interface defines the property as 'proxyApiKey', not 'apiKey'. Updated the getter to use the correct property name.

File: src/app/elohim/services/projection-api.service.ts:106