### PR TITLE
fix(ci): Add package-lock.json for Perseus plugin to fix npm ci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 npm-debug.log
 yarn-error.log
 package-lock.json
+!elohim-library/projects/perseus-plugin/package-lock.json
 
 # Python
 __pycache__/

--- a/elohim-library/projects/perseus-plugin/package-lock.json
+++ b/elohim-library/projects/perseus-plugin/package-lock.json
@@ -1,0 +1,2769 @@
+{
+  "name": "@elohim/perseus-plugin",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@elohim/perseus-plugin",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/kas": "^0.3.11",
+        "@khanacademy/kmath": "^2.2.25",
+        "@khanacademy/math-input": "^26.3.5",
+        "@khanacademy/mathjax-renderer": "^3.0.2",
+        "@khanacademy/perseus": "^72.6.7",
+        "@khanacademy/perseus-core": "^21.1.0",
+        "@khanacademy/perseus-score": "^8.2.1",
+        "@khanacademy/simple-markdown": "^0.12.0",
+        "@khanacademy/wonder-blocks-announcer": "^1.0.5",
+        "@khanacademy/wonder-blocks-banner": "^5.0.7",
+        "@khanacademy/wonder-blocks-button": "^11.2.10",
+        "@khanacademy/wonder-blocks-core": "^12.4.2",
+        "@khanacademy/wonder-blocks-dropdown": "^10.6.1",
+        "@khanacademy/wonder-blocks-form": "^7.4.6",
+        "@khanacademy/wonder-blocks-icon": "^5.3.5",
+        "@khanacademy/wonder-blocks-icon-button": "^11.1.0",
+        "@khanacademy/wonder-blocks-labeled-field": "^4.0.12",
+        "@khanacademy/wonder-blocks-layout": "^3.1.42",
+        "@khanacademy/wonder-blocks-link": "^10.0.6",
+        "@khanacademy/wonder-blocks-popover": "^6.1.48",
+        "@khanacademy/wonder-blocks-progress-spinner": "^3.1.42",
+        "@khanacademy/wonder-blocks-switch": "^3.3.25",
+        "@khanacademy/wonder-blocks-tabs": "^0.4.1",
+        "@khanacademy/wonder-blocks-timing": "^7.0.4",
+        "@khanacademy/wonder-blocks-tokens": "^14.1.3",
+        "@khanacademy/wonder-blocks-tooltip": "^4.1.61",
+        "@khanacademy/wonder-blocks-typography": "^4.2.27",
+        "@khanacademy/wonder-stuff-core": "^3.0.0",
+        "@phosphor-icons/core": "^2.1.1",
+        "@popperjs/core": "^2.11.8",
+        "aphrodite": "^2.4.0",
+        "classnames": "^2.5.1",
+        "jquery": "^3.7.1",
+        "prop-types": "^15.8.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-popper": "^2.3.0",
+        "react-router-dom": "^5.3.4",
+        "react-router-dom-v5-compat": "^6.30.0",
+        "react-transition-group": "^4.4.5",
+        "react-window": "^1.8.11",
+        "underscore": "^1.13.7"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^28.0.0",
+        "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-replace": "^6.0.0",
+        "@rollup/plugin-url": "^8.0.0",
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.7",
+        "esbuild": "^0.27.2",
+        "rollup": "^4.28.0",
+        "rollup-plugin-esbuild": "^6.2.1",
+        "tslib": "^2.3.0",
+        "typescript": "~5.4.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@juggle/resize-observer": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
+      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@khanacademy/kas": {
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@khanacademy/kas/-/kas-0.3.16.tgz",
+      "integrity": "sha512-EHYO6D0FYQnP9FkueglK5nd/GoIfUDKP3Si8N9bIkXPt7k5bq0FgcApXcXcZtVGNzNWNxo+wgDp8/QQazAaTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-core": "1.5.3"
+      },
+      "peerDependencies": {
+        "underscore": "1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/kas/node_modules/@khanacademy/perseus-core": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@khanacademy/perseus-core/-/perseus-core-1.5.3.tgz",
+      "integrity": "sha512-TH3h4h1JE+CANcBM5l2vqj3fXEKeD4TVJ0Hw/pLZ4eDNi5UF7e1vTTqs0fXaV22kfNPRWxEpvKdFfRI6O6pAhQ==",
+      "license": "MIT"
+    },
+    "node_modules/@khanacademy/keypad-context": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/@khanacademy/keypad-context/-/keypad-context-3.2.25.tgz",
+      "integrity": "sha512-c96lqXfefktifFaguk+f2AOPDJFzc9tBroqW0QcdrkX1JPL8C1Hp5+yc31Kw/vTcnrdjgEo6nLDDN/E1HJhykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-core": "21.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/kmath": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/@khanacademy/kmath/-/kmath-2.2.25.tgz",
+      "integrity": "sha512-AX0JgXN+rW8rLgap1P+nL25CeIgS94G7xltHxTH/7LKZJG0ZaCOc03CgK1mZ9xYUJEeYebPoztkwoN5jak0FAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-core": "21.1.0",
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "jquery": "^2.1.1",
+        "underscore": "^1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/math-input": {
+      "version": "26.3.5",
+      "resolved": "https://registry.npmjs.org/@khanacademy/math-input/-/math-input-26.3.5.tgz",
+      "integrity": "sha512-Dqg5pdCjhtY5/XX08tUbrQRKjXRL992j59ULS42irYQL14e4vrjGy7Ydp/Buhp50+G2H9t1Ge2LzjqMeejB64g==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/keypad-context": "3.2.25",
+        "@khanacademy/perseus-core": "21.1.0",
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "@khanacademy/mathjax-renderer": "^3.0.0",
+        "@khanacademy/wonder-blocks-clickable": "^8.0.5",
+        "@khanacademy/wonder-blocks-core": "^12.4.2",
+        "@khanacademy/wonder-blocks-icon-button": "^11.0.1",
+        "@khanacademy/wonder-blocks-popover": "^6.1.47",
+        "@khanacademy/wonder-blocks-tabs": "^0.4.1",
+        "@khanacademy/wonder-blocks-timing": "^7.0.4",
+        "@khanacademy/wonder-blocks-tokens": "^14.1.3",
+        "@khanacademy/wonder-stuff-core": "^3.0.0",
+        "@phosphor-icons/core": "^2.0.2",
+        "aphrodite": "^1.2.5",
+        "jquery": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-transition-group": "^4.4.1"
+      }
+    },
+    "node_modules/@khanacademy/mathjax-renderer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@khanacademy/mathjax-renderer/-/mathjax-renderer-3.0.2.tgz",
+      "integrity": "sha512-Tcp40goSseO52MtRnk29DuGpWXoktJu7BK6HG3mp9rWb7RBLcQldvq++T3FVfIwMA/9EnG1cFboGwNwiFpwrFw==",
+      "dependencies": {
+        "mathjax-full": "3.2.2",
+        "mu-lambda": "^0.0.3"
+      }
+    },
+    "node_modules/@khanacademy/perseus": {
+      "version": "72.6.7",
+      "resolved": "https://registry.npmjs.org/@khanacademy/perseus/-/perseus-72.6.7.tgz",
+      "integrity": "sha512-mZymHQmxYtHrpkpDL2XqJw4uxvxkfnyM5TgTPi8/DqbLElparsj2Q8hk+fUy6sfUMZAiY+mI1zvK9nXUmWeDLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/kas": "2.1.6",
+        "@khanacademy/keypad-context": "3.2.25",
+        "@khanacademy/kmath": "2.2.25",
+        "@khanacademy/math-input": "26.3.5",
+        "@khanacademy/perseus-core": "21.1.0",
+        "@khanacademy/perseus-linter": "4.6.7",
+        "@khanacademy/perseus-score": "8.2.1",
+        "@khanacademy/perseus-utils": "2.1.4",
+        "@khanacademy/pure-markdown": "2.2.4",
+        "@khanacademy/simple-markdown": "2.1.4",
+        "@use-gesture/react": "^10.2.27",
+        "mafs": "0.19.0",
+        "tiny-invariant": "1.3.1",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@khanacademy/wonder-blocks-announcer": "^1.0.5",
+        "@khanacademy/wonder-blocks-banner": "^5.0.6",
+        "@khanacademy/wonder-blocks-button": "^11.2.10",
+        "@khanacademy/wonder-blocks-clickable": "^8.0.5",
+        "@khanacademy/wonder-blocks-core": "^12.4.2",
+        "@khanacademy/wonder-blocks-data": "^15.0.0",
+        "@khanacademy/wonder-blocks-dropdown": "^10.6.0",
+        "@khanacademy/wonder-blocks-form": "^7.4.6",
+        "@khanacademy/wonder-blocks-icon": "^5.3.5",
+        "@khanacademy/wonder-blocks-icon-button": "^11.0.1",
+        "@khanacademy/wonder-blocks-labeled-field": "^4.0.12",
+        "@khanacademy/wonder-blocks-layout": "^3.1.42",
+        "@khanacademy/wonder-blocks-link": "^10.0.6",
+        "@khanacademy/wonder-blocks-modal": "^8.5.9",
+        "@khanacademy/wonder-blocks-pill": "^3.1.48",
+        "@khanacademy/wonder-blocks-popover": "^6.1.47",
+        "@khanacademy/wonder-blocks-progress-spinner": "^3.1.42",
+        "@khanacademy/wonder-blocks-switch": "^3.3.25",
+        "@khanacademy/wonder-blocks-timing": "^7.0.4",
+        "@khanacademy/wonder-blocks-tokens": "^14.1.3",
+        "@khanacademy/wonder-blocks-tooltip": "^4.1.60",
+        "@khanacademy/wonder-blocks-typography": "^4.2.27",
+        "@khanacademy/wonder-stuff-core": "^3.0.0",
+        "@phosphor-icons/core": "^2.0.2",
+        "@popperjs/core": "^2.10.2",
+        "aphrodite": "^1.2.5",
+        "classnames": "^1.1.4",
+        "intersection-observer": "^0.12.0",
+        "jquery": "^2.1.1",
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.8.1",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-popper": "^2.2.5",
+        "underscore": "^1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/perseus-core": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@khanacademy/perseus-core/-/perseus-core-21.1.0.tgz",
+      "integrity": "sha512-Egdo7zE+8WkCm/VBuQF/YxUcExWtLqU38dRCEOgUqNKO+okfZn8HggDOnnaNIY0cOX0M5rTL2q51CDk1goWgqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/kas": "2.1.6",
+        "@khanacademy/perseus-utils": "2.1.4",
+        "@khanacademy/pure-markdown": "2.2.4",
+        "tiny-invariant": "1.3.1"
+      },
+      "peerDependencies": {
+        "@khanacademy/wonder-stuff-core": "^3.0.0",
+        "underscore": "^1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/perseus-core/node_modules/@khanacademy/kas": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@khanacademy/kas/-/kas-2.1.6.tgz",
+      "integrity": "sha512-EmUXj8W6WqmoQuQgL/r0aGUa2YC5+POQxxjL8doAqUo77hmHafYF6c7+XBmKYBlEIDe9RFQBpO8fRT7YL0mnow==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "underscore": "^1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/perseus-linter": {
+      "version": "4.6.7",
+      "resolved": "https://registry.npmjs.org/@khanacademy/perseus-linter/-/perseus-linter-4.6.7.tgz",
+      "integrity": "sha512-oTfc3NJDChhn9EHEW2DrLsXb+Ivo5fmdwKO9+8bn5klhmhRIXNnhyy1yXj2SsZKE4C6YXONfYHXFVV5QptOGNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/kas": "2.1.6",
+        "@khanacademy/kmath": "2.2.25",
+        "@khanacademy/perseus-core": "21.1.0",
+        "@khanacademy/perseus-utils": "2.1.4"
+      }
+    },
+    "node_modules/@khanacademy/perseus-linter/node_modules/@khanacademy/kas": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@khanacademy/kas/-/kas-2.1.6.tgz",
+      "integrity": "sha512-EmUXj8W6WqmoQuQgL/r0aGUa2YC5+POQxxjL8doAqUo77hmHafYF6c7+XBmKYBlEIDe9RFQBpO8fRT7YL0mnow==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "underscore": "^1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/perseus-score": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@khanacademy/perseus-score/-/perseus-score-8.2.1.tgz",
+      "integrity": "sha512-gjVFQqPoRNjylt2XN3+o0OgMI8V9qb4TP+TZxAWiZs+z+5pcvMPmSOWAtSfHLag241U7kA+2SBqZII6YEoD4nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/kas": "2.1.6",
+        "@khanacademy/kmath": "2.2.25",
+        "@khanacademy/perseus-core": "21.1.0",
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "underscore": "^1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/perseus-score/node_modules/@khanacademy/kas": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@khanacademy/kas/-/kas-2.1.6.tgz",
+      "integrity": "sha512-EmUXj8W6WqmoQuQgL/r0aGUa2YC5+POQxxjL8doAqUo77hmHafYF6c7+XBmKYBlEIDe9RFQBpO8fRT7YL0mnow==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "underscore": "^1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/perseus-utils": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@khanacademy/perseus-utils/-/perseus-utils-2.1.4.tgz",
+      "integrity": "sha512-TQLLUZQWc0K0gCLejNTd7G2y1qMhF3BtM9rBGvSObo10EVL4LwA2nCgm0FaPLowCp0ujweZACh9ty+xlekkGXA==",
+      "license": "MIT"
+    },
+    "node_modules/@khanacademy/perseus/node_modules/@khanacademy/kas": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@khanacademy/kas/-/kas-2.1.6.tgz",
+      "integrity": "sha512-EmUXj8W6WqmoQuQgL/r0aGUa2YC5+POQxxjL8doAqUo77hmHafYF6c7+XBmKYBlEIDe9RFQBpO8fRT7YL0mnow==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "underscore": "^1.4.4"
+      }
+    },
+    "node_modules/@khanacademy/perseus/node_modules/@khanacademy/simple-markdown": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@khanacademy/simple-markdown/-/simple-markdown-2.1.4.tgz",
+      "integrity": "sha512-2WBPGtnaCuMS2b6DewdXPbgy14QFo6V22FuMf2PxREQaAHakIOhjQ7sgeswN7ZdAZ1uyGi4TnDbN1qSgIbaC3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/pure-markdown": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@khanacademy/pure-markdown/-/pure-markdown-2.2.4.tgz",
+      "integrity": "sha512-cHjOvhkauQ9Ho17rppahiA7pFUu7zHEYW6KLWz5U+5AdExboKPnY2q78inDGwfy+GwVQLink0Pkz39vEiZApUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-utils": "2.1.4",
+        "@khanacademy/simple-markdown": "2.1.4"
+      }
+    },
+    "node_modules/@khanacademy/pure-markdown/node_modules/@khanacademy/simple-markdown": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@khanacademy/simple-markdown/-/simple-markdown-2.1.4.tgz",
+      "integrity": "sha512-2WBPGtnaCuMS2b6DewdXPbgy14QFo6V22FuMf2PxREQaAHakIOhjQ7sgeswN7ZdAZ1uyGi4TnDbN1qSgIbaC3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-utils": "2.1.4"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/simple-markdown": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@khanacademy/simple-markdown/-/simple-markdown-0.12.1.tgz",
+      "integrity": "sha512-GnrK+mxULyO58pWjPQSU1bVUd892teNIzf7stdBB9mucFDXk2TiplPD9BJDUZ10uGfliyDVKlvwV3BIjHPhL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/perseus-core": "1.5.0"
+      },
+      "peerDependencies": {
+        "react": "16.14.0",
+        "react-dom": "16.14.0"
+      }
+    },
+    "node_modules/@khanacademy/simple-markdown/node_modules/@khanacademy/perseus-core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@khanacademy/perseus-core/-/perseus-core-1.5.0.tgz",
+      "integrity": "sha512-QR9tGBr8nAUFuARSbzgzL6ZkyjDur0Cz9tgQREjC0L+Sug5aj0DHuK86lhosZAbtgAzitX3KVRAsOMbKqU2fYg==",
+      "license": "MIT"
+    },
+    "node_modules/@khanacademy/wonder-blocks-announcer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-announcer/-/wonder-blocks-announcer-1.0.5.tgz",
+      "integrity": "sha512-TIKsXJnuwpb+I81ENIdz7t56j0f7I2xrYWmpWUp0O7xRosi/ZuC5WAinJovLYWVDsT/m6hG7sbaHavAkVwNqnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-banner": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-banner/-/wonder-blocks-banner-5.0.7.tgz",
+      "integrity": "sha512-Z4gKPRyKP1aY7GP5qbOi5uqYkSz59ErJWo7FMGF89zZstZOd/itfK7ODOZ/RXq5QpfhrjrkPd19esyGQFnwk2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-button": "11.2.10",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-icon": "5.3.5",
+        "@khanacademy/wonder-blocks-icon-button": "11.1.0",
+        "@khanacademy/wonder-blocks-link": "10.0.6",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-breadcrumbs": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-breadcrumbs/-/wonder-blocks-breadcrumbs-3.2.9.tgz",
+      "integrity": "sha512-PMMjgYbnU5t+DO23ujhsBw2Z+YG6oik/moGntbdcfaKKK8hGKMJqodB7jolgSQ7fPQ+GSQOekWB7Kk5el0D3qA==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-button": {
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-button/-/wonder-blocks-button-11.2.10.tgz",
+      "integrity": "sha512-lMmfzbeTfSHiljk196C0m5S8MU8vZr2Vb5DP7+hQ2v+P8ibcGSSpdaLesOzR4RIA5D1z7smWCYIL0hrLF4FiiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-clickable": "8.0.5",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-icon": "5.3.5",
+        "@khanacademy/wonder-blocks-progress-spinner": "3.1.42",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-router": "5.3.4",
+        "react-router-dom": "5.3.4",
+        "react-router-dom-v5-compat": "^6.30.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-cell": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-cell/-/wonder-blocks-cell-6.1.5.tgz",
+      "integrity": "sha512-mNlGiI3TOCoVeey8PZVzDabnTNqXC5lw1WwNbB09DB9HP6F0gxVleHmH8cr48Vy5HE2iQ/82VMXoWefI9bD6cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-clickable": "8.0.5",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-clickable": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-clickable/-/wonder-blocks-clickable-8.0.5.tgz",
+      "integrity": "sha512-DXklILRL5C2yuqmmfa6aV4J5yOI2vYLMFdlW6cRE7zQ+sjyy36I+Q88fc6FIOe+Uvxpq0sRdckqq7RCkBcdoZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-router": "5.3.4",
+        "react-router-dom": "5.3.4",
+        "react-router-dom-v5-compat": "^6.30.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-core": {
+      "version": "12.4.2",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-core/-/wonder-blocks-core-12.4.2.tgz",
+      "integrity": "sha512-1w7AlEmrwK727mH9UHj+YexzIPFyWsjbI3l2Hddkqt2e+KD85UqPC1J8mGqZWE/Hu1q27o+qxhqq2wfL4KkSTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-router": "5.3.4",
+        "react-router-dom": "5.3.4",
+        "react-router-dom-v5-compat": "^6.30.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-dropdown": {
+      "version": "10.6.1",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-dropdown/-/wonder-blocks-dropdown-10.6.1.tgz",
+      "integrity": "sha512-vlDyq1Ug9eytRZCFKMZQv/bJyQtRLM3NQ//Iwkm1giPl1e50CXGm9RHMFq2XsjMhlGs+C9S0DdJmSKPaMuRneA==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-announcer": "1.0.5",
+        "@khanacademy/wonder-blocks-cell": "6.1.5",
+        "@khanacademy/wonder-blocks-clickable": "8.0.5",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-form": "7.4.6",
+        "@khanacademy/wonder-blocks-icon": "5.3.5",
+        "@khanacademy/wonder-blocks-icon-button": "11.1.0",
+        "@khanacademy/wonder-blocks-modal": "8.5.10",
+        "@khanacademy/wonder-blocks-pill": "3.1.48",
+        "@khanacademy/wonder-blocks-search-field": "5.1.56",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-timing": "7.0.4",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "@popperjs/core": "^2.10.1",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-popper": "^2.3.0",
+        "react-router": "5.3.4",
+        "react-router-dom": "5.3.4",
+        "react-router-dom-v5-compat": "^6.30.0",
+        "react-window": "^1.8.11"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-form": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-form/-/wonder-blocks-form-7.4.6.tgz",
+      "integrity": "sha512-6fvyNcUeTKMYYqeEdqs3sqFwF6nHjG/BLjw19egeDGthZAZZYQsazYpI29tPf0uQCpBAvJKNJP+d33/up25tLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-clickable": "8.0.5",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-icon": "5.3.5",
+        "@khanacademy/wonder-blocks-layout": "3.1.42",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-icon": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-icon/-/wonder-blocks-icon-5.3.5.tgz",
+      "integrity": "sha512-TGYPeyg17WK62UtcO4HQmxtS6lDfGTXve3tbRI7jYv5z+ZITRFFP+s4kAm46dlDtvOsALh6tnNVNz/iQDAkHyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-icon-button": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-icon-button/-/wonder-blocks-icon-button-11.1.0.tgz",
+      "integrity": "sha512-UW5h0oC/q0gZoHdQhHW3DAXfBKbHI6tLArIi2E5+u5XuRPiM4oQgx5u/h5EQxwAcQh/O9JDVv81PHNLXsEe0Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-clickable": "8.0.5",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-icon": "5.3.5",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-theming": "4.0.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-router": "5.3.4",
+        "react-router-dom": "5.3.4",
+        "react-router-dom-v5-compat": "^6.30.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-labeled-field": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-labeled-field/-/wonder-blocks-labeled-field-4.0.12.tgz",
+      "integrity": "sha512-9jacc1bkR6D9bwrVSEmpBwyeqMUUm3mwVroUbdgsaNVAq1gRiB+gYNwBc+DLGkKNC5BlFC2uuVkkmdSAqA7m/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-layout": "3.1.42",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-layout": {
+      "version": "3.1.42",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-layout/-/wonder-blocks-layout-3.1.42.tgz",
+      "integrity": "sha512-dNuBPyUCQ4P+3W2w2M9DooNUFQudfTh0v0yGrMG5QrhxtLN6efVb5ReWlwIxVYTLcx7P4D8kv9lN3P7ViSKy0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-link": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-link/-/wonder-blocks-link-10.0.6.tgz",
+      "integrity": "sha512-0vdD0nitSEZXIBh8iGVHBqO6ezqowbwrXyvkl36uV92lfPf0ypyPDDNzTs/1x5ME0H7m1+ysf+m6uJl0VjemQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-clickable": "8.0.5",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-icon": "5.3.5",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-router": "5.3.4",
+        "react-router-dom": "5.3.4",
+        "react-router-dom-v5-compat": "^6.30.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-modal": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-modal/-/wonder-blocks-modal-8.5.10.tgz",
+      "integrity": "sha512-Aj5PmgcJt8B/ybeM10mb23SB2VDcV37IPa75GgCtjvf0R5oQSC+3pd65FhC0/sE3jXGAqgekDLBahUAfBbPg6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-breadcrumbs": "3.2.9",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-icon-button": "11.1.0",
+        "@khanacademy/wonder-blocks-layout": "3.1.42",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-timing": "7.0.4",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-pill": {
+      "version": "3.1.48",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-pill/-/wonder-blocks-pill-3.1.48.tgz",
+      "integrity": "sha512-jfbY7Um9unazWofTywpSNvPVRZptp+1zOHS0NTGlENwLaoPna5FoiRA2h3rfjEQkRcAQt/Kpt54uMfMtGA/tow==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-clickable": "8.0.5",
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-link": "10.0.6",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-popover": {
+      "version": "6.1.48",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-popover/-/wonder-blocks-popover-6.1.48.tgz",
+      "integrity": "sha512-ZtQbJLRXqB7auLNZXUY6fozKKh56XqdeoCMgYJJU2pLBo7W81ZhAdq9M9mWzTEfgTPigJXteoEF+JYIUU4teug==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-icon-button": "11.1.0",
+        "@khanacademy/wonder-blocks-modal": "8.5.10",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-tooltip": "4.1.61",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "@popperjs/core": "^2.10.1",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-popper": "^2.3.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-progress-spinner": {
+      "version": "3.1.42",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-progress-spinner/-/wonder-blocks-progress-spinner-3.1.42.tgz",
+      "integrity": "sha512-XnkKAIY8fWLx31bSJxJWGToywO2NjEP+a+XTfKSYna1nfJ7YU2URhhrhmwPq8JO1SieUKzQJZOZTMffa30sLCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-search-field": {
+      "version": "5.1.56",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-search-field/-/wonder-blocks-search-field-5.1.56.tgz",
+      "integrity": "sha512-kvJzqIoHfg5CgwCkZjsjOxt/YdoLb5Aq8Od4dx+PCrD9XvMawZTfNwLeRq9dE2RZt3jGnc0B2hkwavc2U+dKRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-form": "7.4.6",
+        "@khanacademy/wonder-blocks-icon": "5.3.5",
+        "@khanacademy/wonder-blocks-icon-button": "11.1.0",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@phosphor-icons/core": "^2.0.2",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-styles": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-styles/-/wonder-blocks-styles-0.2.37.tgz",
+      "integrity": "sha512-zmy1kZOf8ufcJYE+JS4lVh4Wktzhq4k8PLo4zzvrVTWyMzRhwO+8t/5Px5wqloUWWhIQhRmna4pq07rWOx7atA==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-tokens": "14.1.3"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-switch": {
+      "version": "3.3.25",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-switch/-/wonder-blocks-switch-3.3.25.tgz",
+      "integrity": "sha512-vwrPhVwAz4yq9Nnsv3dA5R+fnJbZDcBE2Egc2khMdNeoY+vF/kV5p5bqfvncyEdTdxKzujCLm6Sapb5SnDsseQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-icon": "5.3.5",
+        "@khanacademy/wonder-blocks-styles": "0.2.37",
+        "@khanacademy/wonder-blocks-theming": "4.0.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-tabs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-tabs/-/wonder-blocks-tabs-0.4.1.tgz",
+      "integrity": "sha512-6dxARev1rFte32wWpvR66JRxLnfGwRCm7tZV1AzILN6PuyRQk1sMGCvx6bplVdrzba9AUm7zEZD1HKxQuZ3wIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-theming": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-theming/-/wonder-blocks-theming-4.0.2.tgz",
+      "integrity": "sha512-NmBNjjP4rsbdzmbBfqTzF+4ahyEokYwsiKnYqAL45EIBBEIXKSLWtTK4+z8k6F5O4EprFTE0qn3hQKEN5+WPhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-timing": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-timing/-/wonder-blocks-timing-7.0.4.tgz",
+      "integrity": "sha512-o+H5ybKjqZrOuF97/WYjVj5TeYlgycCQVWSS0zQnnBfV23912kzMACLPP+KEWNOmbsIFYzIgqUJr5q6FQgLllw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-tokens": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-tokens/-/wonder-blocks-tokens-14.1.3.tgz",
+      "integrity": "sha512-IjW0vZgcKOMHcjr6NdE+czBm5lqLB2xeryR8UtC5jUjjQccVrue4atXnN+mSsDHxGQVOfvEQRbN01/IVkDq5Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-theming": "4.0.2"
+      },
+      "bin": {
+        "wonder-blocks-tokens": "bin/cli.js"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-tooltip": {
+      "version": "4.1.61",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-tooltip/-/wonder-blocks-tooltip-4.1.61.tgz",
+      "integrity": "sha512-5XjvpGFrEqJ5lu7zLQLi1OU1V3/E6NIVgp1qzS+3G1OnQae0nP24XuTZlSiRutTQ3OzxLagL85xhZdqwCYCgqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-layout": "3.1.42",
+        "@khanacademy/wonder-blocks-modal": "8.5.10",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3",
+        "@khanacademy/wonder-blocks-typography": "4.2.27"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.10.1",
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-popper": "^2.3.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-blocks-typography": {
+      "version": "4.2.27",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-blocks-typography/-/wonder-blocks-typography-4.2.27.tgz",
+      "integrity": "sha512-9wcIMwed/Sv+SspAZBPL4XX/i4xwGF8BlrDdlOrLsQPtt7n5RAb4DHFqi7iUjhXutTaU2k2/7NuUDsmwvMZEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@khanacademy/wonder-blocks-core": "12.4.2",
+        "@khanacademy/wonder-blocks-tokens": "14.1.3"
+      },
+      "peerDependencies": {
+        "aphrodite": "^1.2.5",
+        "react": "18.2.0"
+      }
+    },
+    "node_modules/@khanacademy/wonder-stuff-core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@khanacademy/wonder-stuff-core/-/wonder-stuff-core-3.0.0.tgz",
+      "integrity": "sha512-lkq28lY/z/Y4kEhYTMCrbG1ZsZUc0QVbBpz6xHC/4TMCdrwaN6PEeFX2mX4DVaE7bcwi3Y22ZXQmjdxnBpvc2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@phosphor-icons/core": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/core/-/core-2.1.1.tgz",
+      "integrity": "sha512-v4ARvrip4qBCImOE5rmPUylOEK4iiED9ZyKjcvzuezqMaiRASCHKcRIuvvxL/twvLpkfnEODCOJp5dM4eZilxQ==",
+      "license": "MIT"
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "28.0.9",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
+      "integrity": "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-url": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-url/-/plugin-url-8.0.2.tgz",
+      "integrity": "sha512-5yW2LP5NBEgkvIRSSEdJkmxe5cUNZKG3eenKtfJvSkxVm/xTTu7w+ayBtNwhozl1ZnTUCU0xFaRQR+cBl2H7TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "make-dir": "^3.1.0",
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
+      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
+      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
+      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
+      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
+      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
+      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
+      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
+      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
+      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
+      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
+      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
+      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
+      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
+      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
+      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
+      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
+      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
+      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
+      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
+      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
+      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/aphrodite": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/aphrodite/-/aphrodite-2.4.0.tgz",
+      "integrity": "sha512-1rVRlLco+j1YAT5aKEE8Wuw5zWV+tI41/quEheJAG0vNaGHE64iJ/a2SiVMz8Uc80VdP2/Hjlfd2bPJOWsqJuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "^2.0.3",
+        "inline-style-prefixer": "^5.1.0",
+        "string-hash": "^1.1.3"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/computer-modern": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/computer-modern/-/computer-modern-0.1.3.tgz",
+      "integrity": "sha512-tJz506hr2RPksqdYs0VJz98gE1TcpYs/L/kk5MTkEbtgCLRJ1xwcL8rXkzsSnyBqNCyrI+1paZE8Jat6d7wN2Q==",
+      "license": "MIT"
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "license": "MIT",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-5.1.2.tgz",
+      "integrity": "sha512-PYUF+94gDfhy+LsQxM0g3d6Hge4l1pAqOSOiZuHWzMvQEGsbRQ/ck2WioLqrY2ZkHyPgVUXxn+hrkF7D6QUGbA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-in-js-utils": "^2.0.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/katex": {
+      "version": "0.16.27",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.27.tgz",
+      "integrity": "sha512-aeQoDkuRWSqQN6nSvVCEFvfXdqo1OQiCmmW1kc9xSdjutPv7BGO7pqY9sQRJpMOGrEdfDgF2TfRXe5eUAD2Waw==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/mafs": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/mafs/-/mafs-0.19.0.tgz",
+      "integrity": "sha512-mDHQhCbkIYjpuycY8mMV8O+o3ZOIGPgxliipcRE6aBGOXFvlwP2qvz9FQFdIr5W/BfcMY7CkgOqbPQJiKCr74w==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/react": "^10.2.27",
+        "computer-modern": "^0.1.2",
+        "katex": "^0.16",
+        "tiny-invariant": "^1.3.1",
+        "use-resize-observer": "^9"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "deprecated": "Version 4 replaces this package with the scoped package @mathjax/src",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mu-lambda": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mu-lambda/-/mu-lambda-0.0.3.tgz",
+      "integrity": "sha512-t5mnn/RizL/UCERDxqFQyIEMhjAbq+xohNW/hZzL40NRxkhmXIlDyjK59tj41ltPgXOtpE/w1wAiqvnOhF13og==",
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.3.4",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat": {
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.30.0.tgz",
+      "integrity": "sha512-MAVRASbdQ3+ZOTPPjAa7jKcF0F9LkHWKB/iib3hf+jzzIazL4GEpMDDdTswCsqRQNU+zNnT3qD0WiNbzJ6ncPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "history": "^5.3.0",
+        "react-router": "6.30.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8",
+        "react-router-dom": "4 || 5"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
+    "node_modules/react-router-dom-v5-compat/node_modules/react-router": {
+      "version": "6.30.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.0.tgz",
+      "integrity": "sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
+      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.54.0",
+        "@rollup/rollup-android-arm64": "4.54.0",
+        "@rollup/rollup-darwin-arm64": "4.54.0",
+        "@rollup/rollup-darwin-x64": "4.54.0",
+        "@rollup/rollup-freebsd-arm64": "4.54.0",
+        "@rollup/rollup-freebsd-x64": "4.54.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
+        "@rollup/rollup-linux-arm64-musl": "4.54.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-gnu": "4.54.0",
+        "@rollup/rollup-linux-x64-musl": "4.54.0",
+        "@rollup/rollup-openharmony-arm64": "4.54.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
+        "@rollup/rollup-win32-x64-gnu": "4.54.0",
+        "@rollup/rollup-win32-x64-msvc": "4.54.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-esbuild": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-esbuild/-/rollup-plugin-esbuild-6.2.1.tgz",
+      "integrity": "sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "es-module-lexer": "^1.6.0",
+        "get-tsconfig": "^4.10.0",
+        "unplugin-utils": "^0.2.4"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18.0",
+        "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/speech-rule-engine": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.2.tgz",
+      "integrity": "sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.8",
+        "commander": "13.1.0",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
+    "node_modules/speech-rule-engine/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.2.5.tgz",
+      "integrity": "sha512-gwXJnPRewT4rT7sBi/IvxKTjsms7jX7QIDLOClApuZwR49SXbrB1z2NLUZ+vDHyqCj/n58OzRRqaW+B8OZi8vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/use-resize-observer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
+      "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+      "license": "MIT",
+      "dependencies": {
+        "@juggle/resize-observer": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "16.8.0 - 18",
+        "react-dom": "16.8.0 - 18"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
+      "license": "MIT"
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
The dev pipeline was failing because npm ci requires a package-lock.json file. This adds the lock file for the Perseus plugin and updates .gitignore to allow tracking it.