### PR TITLE
fix(perseus): Load questions when node input changes, not just on init

### DIFF
--- a/elohim-app/src/app/lamad/content-io/plugins/perseus/perseus-renderer.component.ts
+++ b/elohim-app/src/app/lamad/content-io/plugins/perseus/perseus-renderer.component.ts
@@ -6,6 +6,8 @@ import {
   ViewChild,
   OnInit,
   OnDestroy,
+  OnChanges,
+  SimpleChanges,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   inject
@@ -305,7 +307,7 @@ import type { PerseusItem, PerseusScoreResult } from './perseus-item.model';
   `],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class PerseusRendererComponent implements ContentRenderer, InteractiveRenderer, OnInit, OnDestroy {
+export class PerseusRendererComponent implements ContentRenderer, InteractiveRenderer, OnInit, OnChanges, OnDestroy {
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly destroy$ = new Subject<void>();
 
@@ -406,8 +408,15 @@ export class PerseusRendererComponent implements ContentRenderer, InteractiveRen
   // ─────────────────────────────────────────────────────────────────────────
 
   ngOnInit(): void {
-    this.loadQuestions();
     this.initializeStreakTracking();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    // Load questions when node is set or changes
+    if (changes['node'] && this.node) {
+      this.loadQuestions();
+      this.cdr.markForCheck();
+    }
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
The PerseusRendererComponent was calling loadQuestions() in ngOnInit, but the parent ContentViewerComponent sets the node input via setInput() after ngOnInit has already executed. This caused the "No question loaded" message to appear.

Fixed by implementing OnChanges and calling loadQuestions() when the node input is actually set/changed, ensuring questions are properly loaded regardless of when the input is provided.