### PR TITLE
fix(happ-installer): Use node:20-slim for ESM module compatibility

### DIFF
--- a/holochain/edgenode/scripts/Dockerfile
+++ b/holochain/edgenode/scripts/Dockerfile
@@ -1,7 +1,9 @@
 # hApp Installer Container
 # Installs the hApp on conductor startup as a sidecar
 
-FROM node:20-alpine
+# Use slim instead of alpine for better ESM module compatibility
+# (libsodium-wrappers has ESM resolution issues on Alpine)
+FROM node:20-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
The libsodium-wrappers package has ESM module resolution issues on Alpine, causing the happ-installer to fail with ERR_MODULE_NOT_FOUND. Switching to node:20-slim (Debian-based) resolves this compatibility issue.