### PR TITLE
fix(edge): increase rollout status timeout to 600s

### DIFF
--- a/holochain/Jenkinsfile
+++ b/holochain/Jenkinsfile
@@ -207,7 +207,7 @@ def deployEdgeWithManifest(String env, String namespace, String manifestTemplate
         returnStdout: true
     ).trim()
     sh "kubectl rollout restart ${resourceType}/${resourceName}-${env} -n ${namespace}"
-    sh "kubectl rollout status ${resourceType}/${resourceName}-${env} -n ${namespace} --timeout=300s"
+    sh "kubectl rollout status ${resourceType}/${resourceName}-${env} -n ${namespace} --timeout=600s"
 }
 
 pipeline {


### PR DESCRIPTION
6-container edgenode pod can exceed the 300s timeout during image pulls and health checks, causing false pipeline failures.