### PR TITLE
perf(elohim-client): parallelize getBatch fetches

### DIFF
--- a/app/elohim-library/projects/elohim-service/src/client/elohim-client.ts
+++ b/app/elohim-library/projects/elohim-service/src/client/elohim-client.ts
@@ -261,16 +261,16 @@ export class ElohimClient {
     contentType: ContentType,
     ids: string[]
   ): Promise<Map<string, T>> {
-    const results = new Map<string, T>();
+    const fetched = await Promise.all(
+      ids.map(async id => [id, await this.get<T>(contentType, id)] as const)
+    );
 
-    // TODO: Implement batch endpoint for better performance
-    for (const id of ids) {
-      const content = await this.get<T>(contentType, id);
+    const results = new Map<string, T>();
+    for (const [id, content] of fetched) {
       if (content) {
         results.set(id, content);
       }
     }
-
     return results;
   }
 


### PR DESCRIPTION
Previously getBatch awaited each single-id GET in a loop, making
the operation strictly serial. Parallelize with Promise.all so the
batch runs as fast as the slowest request rather than the sum.